### PR TITLE
feat: Clear QML cache after installation

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm -rf  /home/*/.cache/deepin/dde-control-center/qmlcache/


### PR DESCRIPTION
Force cache refresh after installation to avoid the problem of cache not being updated in a timely manner

pms TASK-368711