### PR TITLE
feat: add update module with privacy agreement and UI improvements

### DIFF
--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -1211,6 +1211,29 @@ void UpdateModel::updateAvailableState()
     setIsUpdatable(false);
 }
 
+QString UpdateModel::privacyAgreementText() const
+{
+    static QStringList supportedRegion = { "cn", "en", "tw", "hk", "ti", "uy" };
+    static QStringList communitySupportRegion = { "cn", "en" };
+    const QString& systemLocaleName = QLocale::system().name();
+    if (systemLocaleName.length() != QString("zh_CN").length()) {
+        qCWarning(DCC_UPDATE_MODEL) << "Get system locale name failed:" << systemLocaleName;
+    }
+    QString region = systemLocaleName.right(2).toLower();
+
+    QString addr = "https://www.uniontech.com/agreement/privacy-";
+    if (DCC_NAMESPACE::IsCommunitySystem) {
+        addr = "https://www.uniontech.com/agreement/deepin-privacy-";
+        if (!communitySupportRegion.contains(region))
+            region = "en";
+    } else if (!supportedRegion.contains(region)) {
+        region = "en";
+    }
+
+    QString link = QString("<a style=\"text-decoration: none\" href=\"%1%2\">%3</a>").arg(addr).arg(region).arg(tr("Privacy Policy"));
+    return tr("To use this software, you must accept the %1 that accompanies software updates.").arg(link);
+}
+
 void UpdateModel::setShowCheckUpdate(bool value)
 {
     if (m_showCheckUpdate == value)

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -336,6 +336,8 @@ public:
 
     void updateAvailableState();
 
+    Q_INVOKABLE QString privacyAgreementText() const;
+
 public slots:
     void onUpdatePropertiesChanged(const QString &interfaceName,
                                    const QVariantMap &changedProperties,

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -382,6 +382,7 @@ void UpdateWorker::checkForUpdates()
         || allUpdateStatuses.contains(Downloading)
         || allUpdateStatuses.contains(DownloadPaused)) {
         qCInfo(DCC_UPDATE_WORKER) << "Lastore daemon is busy now, current statuses:" << allUpdateStatuses;
+        m_model->setShowCheckUpdate(false);
         return;
     }
 
@@ -795,8 +796,7 @@ bool UpdateWorker::openTestingChannelUrl()
     }
     QUrl testChannelUrl = testChannelUrlOpt.value();
     qCDebug(DCC_UPDATE_WORKER) << "Testing:" << "open join page" << testChannelUrl.toString();
-    QDesktopServices::openUrl(testChannelUrl);
-    return true;
+    return openUrl(testChannelUrl.toString());
 }
 
 void UpdateWorker::exitTestingChannel(bool value)
@@ -1652,6 +1652,11 @@ void UpdateWorker::stopDownload()
     }
 
     cleanLaStoreJob(m_downloadJob);
+}
+
+bool UpdateWorker::openUrl(const QString& url)
+{
+    return QDesktopServices::openUrl(QUrl(url));
 }
 
 /**

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -113,6 +113,8 @@ public Q_SLOTS:
     void doUpgrade(int updateTypes, bool doBackup);
     void stopDownload();
 
+    Q_INVOKABLE bool openUrl(const QString& url);
+
 private Q_SLOTS:
     void setCheckUpdatesJob(const QString& jobPath);
     void onJobListChanged(const QList<QDBusObjectPath>& jobs);

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -109,6 +109,7 @@ Rectangle {
                             Layout.fillWidth: true
                             opacity: 0.7
                             wrapMode: Text.WordWrap
+                            visible: false
                         }
 
                         D.Label {

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -42,12 +42,75 @@ DccObject {
         page: CheckUpdate {}
     }
 
+    // 正在安装列表
+    DccObject {
+        name: "installingList"
+        parentName: "update"
+        backgroundType: DccObject.Normal
+        weight: 30
+        visible: !dccData.model().showCheckUpdate && dccData.model().installinglistModel.anyVisible
+        pageType: DccObject.Item
+
+        page: UpdateControl {
+            updateListModels: dccData.model().installinglistModel
+            updateTitle: qsTr("Installing updates...")
+            processTitle: qsTr("Installing")
+            processValue: dccData.model().distUpgradeProgress
+            updateListEnable: false
+        }
+    }
+
+    // 正在备份列表
+    DccObject {
+        name: "backupList"
+        parentName: "update"
+        backgroundType: DccObject.Normal
+        weight: 40
+        visible: !dccData.model().showCheckUpdate && dccData.model().backingUpListModel.anyVisible
+        pageType: DccObject.Item
+
+        page: UpdateControl {
+            updateListModels: dccData.model().backingUpListModel
+            updateTitle: qsTr("Backing up in progress...")
+            processTitle: qsTr("Backing up in progress")
+            processValue: dccData.model().backupProgress
+            updateListEnable: false
+        }
+    }
+    
+    // 正在下载列表
+    DccObject {
+        name: "downloadingList"
+        parentName: "update"
+        backgroundType: DccObject.Normal
+        weight: 50
+        visible: !dccData.model().showCheckUpdate && dccData.model().downloadinglistModel.anyVisible
+        pageType: DccObject.Item
+
+        page: UpdateControl {
+            updateListModels: dccData.model().downloadinglistModel
+            updateTitle: qsTr("Downloading updates...")
+            updateTips: qsTr("Update size: ") + dccData.model().downloadinglistModel.downloadSize
+            processTitle: qsTr("Downloading")
+            processValue: dccData.model().downloadProgress
+            updateListEnable: false
+
+            onDownloadJobCtrl: function(updateCtrlType) {
+                dccData.work().onDownloadJobCtrl(updateCtrlType)
+            }
+
+            onCloseDownload: {
+                dccData.work().stopDownload()
+            }
+        }
+    }    
+
     // 安装完成列表
     DccObject {
         name: "installCompleteList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 30
+        weight: 60
         visible: !dccData.model().showCheckUpdate && dccData.model().installCompleteListModel.anyVisible
         pageType: DccObject.Item
 
@@ -69,7 +132,7 @@ DccObject {
         name: "installFailedList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 35
+        weight: 70
         visible: !dccData.model().showCheckUpdate && dccData.model().installFailedListModel.anyVisible
         pageType: DccObject.Item
 
@@ -86,30 +149,33 @@ DccObject {
         }
     }
 
-    // 正在安装列表
+    // 备份失败列表
     DccObject {
-        name: "installingList"
+        name: "backupFailedList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 40
-        visible: !dccData.model().showCheckUpdate && dccData.model().installinglistModel.anyVisible
+        weight: 80
+        visible: !dccData.model().showCheckUpdate && dccData.model().backupFailedListModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
-            updateListModels: dccData.model().installinglistModel
-            updateTitle: qsTr("Installing updates...")
-            processTitle: qsTr("Installing")
-            processValue: dccData.model().distUpgradeProgress
-            updateListEnable: false
+            updateListModels: dccData.model().backupFailedListModel
+            processTitle: qsTr("Backup failed")
+            updateTitle: qsTr("Backup failed")
+            updateTips: dccData.model().backUpFailedTips
+            onBtnClicked: function(updateType) {
+            actionBtnText: qsTr("Back Up Again")
+                dccData.work().onRequestRetry(3, updateType)
+            }
         }
-    }
+    }    
 
     // 下载完成列表
     DccObject {
         name: "preInstallList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 50
+        weight: 90
         visible: !dccData.model().showCheckUpdate && dccData.model().preInstallListModel.anyVisible
         pageType: DccObject.Item
 
@@ -130,7 +196,7 @@ DccObject {
         name: "downloadFailedList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 60
+        weight: 100
         visible: !dccData.model().showCheckUpdate && dccData.model().downloadFailedListModel.anyVisible
         pageType: DccObject.Item
 
@@ -146,39 +212,12 @@ DccObject {
         }
     }
 
-    // 正在下载列表
-    DccObject {
-        name: "downloadingList"
-        parentName: "update"
-        backgroundType: DccObject.Normal
-        weight: 65
-        visible: !dccData.model().showCheckUpdate && dccData.model().downloadinglistModel.anyVisible
-        pageType: DccObject.Item
-
-        page: UpdateControl {
-            updateListModels: dccData.model().downloadinglistModel
-            updateTitle: qsTr("Downloading updates...")
-            updateTips: qsTr("Update size: ") + dccData.model().downloadinglistModel.downloadSize
-            processTitle: qsTr("Downloading")
-            processValue: dccData.model().downloadProgress
-            updateListEnable: false
-
-            onDownloadJobCtrl: function(updateCtrlType) {
-                dccData.work().onDownloadJobCtrl(updateCtrlType)
-            }
-
-            onCloseDownload: {
-                dccData.work().stopDownload()
-            }
-        }
-    }
-
     // 检测到可更新列表
     DccObject {
         name: "preUpdateList"
         parentName: "update"
         backgroundType: DccObject.Normal
-        weight: 70
+        weight: 110
         visible: !dccData.model().showCheckUpdate && dccData.model().preUpdatelistModel.anyVisible
         pageType: DccObject.Item
 
@@ -194,45 +233,6 @@ DccObject {
         }
     }
 
-    // 正在备份列表
-    DccObject {
-        name: "backupList"
-        parentName: "update"
-        backgroundType: DccObject.Normal
-        weight: 80
-        visible: !dccData.model().showCheckUpdate && dccData.model().backingUpListModel.anyVisible
-        pageType: DccObject.Item
-
-        page: UpdateControl {
-            updateListModels: dccData.model().backingUpListModel
-            updateTitle: qsTr("Backing up in progress...")
-            processTitle: qsTr("Backing up in progress")
-            processValue: dccData.model().backupProgress
-            updateListEnable: false
-        }
-    }
-
-    // 备份失败列表
-    DccObject {
-        name: "backupFailedList"
-        parentName: "update"
-        backgroundType: DccObject.Normal
-        weight: 90
-        visible: !dccData.model().showCheckUpdate && dccData.model().backupFailedListModel.anyVisible
-        pageType: DccObject.Item
-
-        page: UpdateControl {
-            updateListModels: dccData.model().backupFailedListModel
-            processTitle: qsTr("Backup failed")
-            updateTitle: qsTr("Backup failed")
-            updateTips: dccData.model().backUpFailedTips
-            onBtnClicked: function(updateType) {
-            actionBtnText: qsTr("Back Up Again")
-                dccData.work().onRequestRetry(3, updateType)
-            }
-        }
-    }
-
     // 更新设置
     DccObject {
         name: "updateSettingsPage"
@@ -240,9 +240,38 @@ DccObject {
         displayName: qsTr("Update Settings")
         description: qsTr("Configure Update settings、Security Updates、Auto Download Updates and Updates Notification")
         icon: "update_set"
-        weight: 100
+        weight: 120
         visible: false //dccData.model().systemActivation
 
         UpdateSetting {}
+    }
+
+    // 隐私协议
+    DccObject {
+        name: "privacyAgreement"
+        parentName: "update"
+        weight: 130
+        backgroundType: DccObject.Normal
+        visible: !dccData.model().showCheckUpdate
+        pageType: DccObject.Item
+
+        page: RowLayout {
+            Rectangle {
+                color: 'transparent'
+                Layout.fillWidth: true
+                Layout.preferredHeight: 40
+                D.Label {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 10
+                    anchors.verticalCenter: parent.verticalCenter
+                    font.pixelSize: 12
+                    textFormat: Text.RichText
+                    text: dccData.model().privacyAgreementText()
+                    onLinkActivated: (link)=> {
+                        dccData.work().openUrl(link)
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
1. Added privacyAgreementText() method to UpdateModel for localized privacy policy links
2. Implemented openUrl() helper method in UpdateWorker for URL handling
3. Reorganized update status pages with proper weighting and visibility logic
4. Added new privacy agreement display component in QML
5. Fixed download state handling by setting showCheckUpdate flag

feat: 增加更新模块的隐私协议和UI改进

1. 在UpdateModel中添加privacyAgreementText()方法用于本地化隐私政策链接
2. 在UpdateWorker中实现openUrl()辅助方法处理URL
3. 重新组织更新状态页面，优化权重和显示逻辑
4. 在QML中添加新的隐私协议显示组件
5. 通过设置showCheckUpdate标志修复下载状态处理

pms: Bug-314999
pms: Bug-314943
pms: Bug-314673
pms: Bug-313865