### PR TITLE
fix: installation status optimization

### DIFF
--- a/src/dcc-update-plugin/operation/updatelistmodel.cpp
+++ b/src/dcc-update-plugin/operation/updatelistmodel.cpp
@@ -128,6 +128,14 @@ QString UpdateListModel::downloadSize() const
     return m_downloadSize;
 }
 
+UpdateType UpdateListModel::getUpdateType(int index) const
+{
+    if (index >= 0 && index < m_updateLists.count()) {
+        return m_updateLists[index]->updateType();
+    }
+    return Invalid;
+}
+
 void UpdateListModel::clearAllData()
 {
     beginResetModel();

--- a/src/dcc-update-plugin/operation/updatelistmodel.h
+++ b/src/dcc-update-plugin/operation/updatelistmodel.h
@@ -4,6 +4,7 @@
 #define UPDATELISTMODEL_H
 
 #include "updateiteminfo.h"
+#include "common.h"
 
 #include <QAbstractListModel>
 
@@ -59,6 +60,8 @@ public:
     bool anyVisible() const;
     bool isUpdateEnable() const;
     QString downloadSize() const;
+
+    Q_INVOKABLE UpdateType getUpdateType(int index) const;
 
 public Q_SLOTS:
     void refreshDownloadSize();

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -45,6 +45,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(UpdateListModel *backupFailedListModel READ backupFailedListModel NOTIFY backupFailedListModelChanged FINAL)    
 
     Q_PROPERTY(bool downloadWaiting READ downloadWaiting NOTIFY downloadWaitingChanged FINAL)
+    Q_PROPERTY(bool upgradeWaiting READ upgradeWaiting NOTIFY upgradeWaitingChanged FINAL)
 
     Q_PROPERTY(double downloadProgress READ downloadProgress NOTIFY downloadProgressChanged FINAL)
     Q_PROPERTY(double backupProgress READ backupProgress NOTIFY backupProgressChanged FINAL)
@@ -152,6 +153,9 @@ public:
 
     bool downloadWaiting() const { return m_downloadWaiting; }
     void setDownloadWaiting(bool waiting);
+
+    bool upgradeWaiting() const { return m_upgradeWaiting; }
+    void setUpgradeWaiting(bool waiting);
 
     double downloadProgress() const { return m_downloadProgress; }
     void setDownloadProgress(double downloadProgress);
@@ -314,6 +318,7 @@ Q_SIGNALS:
     void backupFailedListModelChanged();
 
     void downloadWaitingChanged(bool waiting);
+    void upgradeWaitingChanged(bool waiting);
 
     void downloadProgressChanged(const double &progress);
     void backupProgressChanged(double progress);
@@ -379,6 +384,7 @@ private:
     UpdateListModel *m_backingUpListModel; // backing up qml data
     UpdateListModel *m_backupFailedListModel; // backup failed qml data
     bool m_downloadWaiting;
+    bool m_upgradeWaiting;
     double m_downloadProgress;
     double m_distUpgradeProgress;
     double m_backupProgress;

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -100,6 +100,8 @@ public:
     Q_INVOKABLE bool openUrl(const QString& url);
     Q_INVOKABLE void onRequestRetry(int type, int updateTypes);
 
+    Q_INVOKABLE void setCheckUpdateMode(int type, bool isChecked);
+
 public Q_SLOTS:
     void onLicenseStateChange();
     void onPowerChange();
@@ -108,7 +110,6 @@ public Q_SLOTS:
     void onUpdateStatusChanged(const QString& value);
     void onClassifiedUpdatablePackagesChanged(const QMap<QString, QStringList>& packages);
 
-    void onRequestCheckUpdateModeChanged(int type, bool isChecked);
     void onCheckUpdateStatusChanged(const QString& value);
     void onDownloadStatusChanged(const QString& value);
     void onBackupStatusChanged(const QString& value);

--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -21,6 +21,7 @@ ColumnLayout {
     property bool processState: false
     property bool busyState: false
     property bool updateListEnable: true
+    property bool isPauseOrNot: false
 
     signal btnClicked(int index, int updateType)
     signal downloadJobCtrl(int updateCtrlType)
@@ -94,7 +95,7 @@ ColumnLayout {
         }
 
         ColumnLayout {
-            visible: processValue !== 0 && processValue !== 1
+            visible: processState
             Layout.rightMargin: 12
             Layout.alignment: Qt.AlignRight
 
@@ -120,8 +121,8 @@ ColumnLayout {
                 //     height: 12
 
                 //     onClicked: {
-                //         processState = !processState
-                //         rootLayout.downloadJobCtrl(processState)
+                //         isPauseOrNot = !isPauseOrNot
+                //         rootLayout.downloadJobCtrl(isPauseOrNot)
                 //     }
                 // }
 

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.15
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
 import org.deepin.dcc 1.0
+import org.deepin.dcc.update 1.0
 
 Rectangle {
     id: root
@@ -70,6 +71,7 @@ Rectangle {
 
                                 onClicked: {
                                     repeater.model.setChecked(index, !model.checked)
+                                    dccData.work().setCheckUpdateMode(repeater.model.getUpdateType(index), model.checked)
                                 }
                             }
                         }

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -58,6 +58,7 @@ DccObject {
             updateTitle: qsTr("Installing updates...")
             processTitle: qsTr("Installing")
             processValue: dccData.model().distUpgradeProgress
+            processState: true
             updateListEnable: false
         }
     }
@@ -76,6 +77,7 @@ DccObject {
             updateTitle: qsTr("Backing up in progress...")
             processTitle: qsTr("Backing up in progress")
             processValue: dccData.model().backupProgress
+            processState: true
             updateListEnable: false
         }
     }
@@ -95,6 +97,7 @@ DccObject {
             updateTips: qsTr("Update size: ") + dccData.model().downloadinglistModel.downloadSize
             processTitle: qsTr("Downloading")
             processValue: dccData.model().downloadProgress
+            processState: true
             updateListEnable: false
 
             onDownloadJobCtrl: function(updateCtrlType) {
@@ -136,6 +139,7 @@ DccObject {
         backgroundType: DccObject.Normal
         weight: 70
         visible: !dccData.model().showCheckUpdate && dccData.model().installFailedListModel.anyVisible
+        enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -175,7 +179,7 @@ DccObject {
                 }
             }
         }
-    }   
+    }
 
     // 下载完成列表
     DccObject {
@@ -184,6 +188,7 @@ DccObject {
         backgroundType: DccObject.Normal
         weight: 90
         visible: !dccData.model().showCheckUpdate && dccData.model().preInstallListModel.anyVisible
+        enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -191,6 +196,8 @@ DccObject {
             updateTitle: qsTr("Update download completed")
             btnActions: [ qsTr("Install updates") ]
             updateTips: qsTr("Update size: ") + dccData.model().preInstallListModel.downloadSize
+            busyState: dccData.model().upgradeWaiting
+            updateListEnable: !dccData.model().upgradeWaiting
 
             onBtnClicked: function(index, updateType) {
                 dccData.work().doUpgrade(updateType, true)
@@ -205,6 +212,7 @@ DccObject {
         backgroundType: DccObject.Normal
         weight: 100
         visible: !dccData.model().showCheckUpdate && dccData.model().downloadFailedListModel.anyVisible
+        enabled: !dccData.model().downloadinglistModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -212,6 +220,8 @@ DccObject {
             updateTitle: qsTr("Update download failed")
             btnActions: [ qsTr("Retry") ]
             updateTips: dccData.model().installFailedTips
+            busyState: dccData.model().upgradeWaiting
+            updateListEnable: !dccData.model().upgradeWaiting
 
             onBtnClicked: function(index, updateType) {
                 dccData.work().onRequestRetry(Common.CPT_DownloadFailed, updateType)
@@ -251,7 +261,7 @@ DccObject {
         description: qsTr("Configure Update settings、Security Updates、Auto Download Updates and Updates Notification")
         icon: "update_set"
         weight: 120
-        visible: false //dccData.model().systemActivation
+        visible: dccData.model().systemActivation
 
         UpdateSetting {}
     }


### PR DESCRIPTION
1. There will be no blank pages after the backup is completed
2. During the installation process, other uninstalled lists cannot be clicked on
3. Open the update settings option

pms: Bug-313751
pms: Bug-314671