### PR TITLE
fix: updates cannot be detected When all update models are disabled

### DIFF
--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -182,20 +182,23 @@ void UpdateModel::updateCheckUpdateUi()
         case Checking:
             setCheckUpdateErrTips(tr("Checking for updates, please wait…"));
             setCheckUpdateIcon("updating");
-            setCheckBtnText(tr(""));
-            break;
-        case UpdatesAvailable:
-            break;
-        case Updated:
-            setCheckBtnText(tr("Check Again"));
-            setCheckUpdateErrTips(tr("Your system is up to date"));
-            setCheckUpdateIcon("update_abreast_of_time");
+            setCheckBtnText("");
             break;
         case CheckingFailed:
             setCheckUpdateErrTips(errorToText(lastError(CheckingFailed)));
             setCheckUpdateIcon("update_failure");
             setCheckBtnText(tr("Check Again"));
             break;
+        case Updated:
+            setCheckBtnText(tr("Check Again"));
+            setCheckUpdateErrTips(tr("Your system is up to date"));
+            setCheckUpdateIcon("update_abreast_of_time");
+            break;
+        case AllUpdateModeDisabled:
+            setCheckUpdateErrTips(tr("Turn on the switches under Update Content to get better experiences"));
+            setCheckUpdateIcon("update_nice_service");
+            setCheckBtnText("");
+            break;            
         default:
             setCheckBtnText(tr(""));
             return;
@@ -835,6 +838,11 @@ bool UpdateModel::securityUpdate() const
 bool UpdateModel::thirdPartyUpdate() const 
 { 
     return m_updateMode & UpdateType::UnknownUpdate; 
+}
+
+bool UpdateModel::updateModeDisabled() const
+{
+    return m_updateMode == UpdateType::Invalid;
 }
 
 void UpdateModel::setUpdateMode(quint64 updateMode)

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -64,6 +64,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(bool functionUpdate READ functionUpdate NOTIFY updateModeChanged FINAL)
     Q_PROPERTY(bool securityUpdate READ securityUpdate NOTIFY updateModeChanged FINAL)
     Q_PROPERTY(bool thirdPartyUpdate READ thirdPartyUpdate NOTIFY updateModeChanged FINAL)
+    Q_PROPERTY(bool updateModeDisabled READ updateModeDisabled NOTIFY updateModeChanged FINAL)
     Q_PROPERTY(bool downloadSpeedLimitEnabled READ downloadSpeedLimitEnabled NOTIFY downloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString downloadSpeedLimitSize READ downloadSpeedLimitSize NOTIFY downloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool autoDownloadUpdates READ autoDownloadUpdates WRITE setAutoDownloadUpdates NOTIFY autoDownloadUpdatesChanged FINAL)
@@ -223,6 +224,7 @@ public:
     bool functionUpdate() const;
     bool securityUpdate() const;
     bool thirdPartyUpdate() const;
+    bool updateModeDisabled() const;
     quint64 updateMode() const { return m_updateMode; }
     void setUpdateMode(quint64 updateMode);
     void setUpdateItemEnabled();

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -371,6 +371,12 @@ UpdateErrorType UpdateWorker::analyzeJobErrorMessage(const QString& jobDescripti
 
 void UpdateWorker::checkNeedDoUpdates()
 {
+    if (m_model->updateModeDisabled()) {
+        m_model->setShowCheckUpdate(true);
+        m_model->setCheckUpdateStatus(UpdatesStatus::AllUpdateModeDisabled);
+        return;
+    }
+
     if (m_model->isUpdateDisabled() || !m_model->systemActivation()) {
         qCDebug(DCC_UPDATE_WORKER) << "update disabled:" << m_model->isUpdateDisabled() << " system activation:" << m_model->systemActivation();
         m_model->setShowCheckUpdate(false);
@@ -1288,6 +1294,13 @@ void UpdateWorker::onPowerChange()
 void UpdateWorker::onUpdateModeChanged(qulonglong value)
 {
     m_model->setUpdateMode(value);
+
+    if (m_model->updateModeDisabled()) {
+        m_model->setShowCheckUpdate(true);
+        m_model->setCheckUpdateStatus(UpdatesStatus::AllUpdateModeDisabled);
+    } else {
+        m_model->setShowCheckUpdate(false);
+    }
 }
 
 void UpdateWorker::onJobListChanged(const QList<QDBusObjectPath>& jobs)

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Per usar aquest programari, cal que accepteu la %1 que acompanya les actualitzacions del programari.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Para utilizar este software, debe aceptar el %1 que acompaña a las actualizaciones de software.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Jotta voit käyttää tätä ohjelmistoa, sinun on hyväksyttävä ohjelmistopäivitysten mukana tuleva %1.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Om deze software te kunnen gebruiken, dien je akkoord te gaan met het %1 omtrent software-updates.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Aby korzystać z tego oprogramowania, musisz zaakceptować %1, dołączone do aktualizacji.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Që të përdorni këtë software, duhet të pranoni %1 që shoqëron përditësimet e software-it.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>Щоб користуватися програмним забезпеченням, вам слід погодитися із %1, яка є супутньою до оновлень програмного забезпечення.</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>使用此软件需要接受软件更新时附带的%1</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation>开启更新内容开关，可以获得更优质的功能体验哦</translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>使用此軟件需要接受軟件更新時附帶的%1</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -224,6 +224,10 @@
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
         <translation>使用此軟體需要接受軟體更新時附帶的%1</translation>
     </message>
+    <message>
+        <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>


### PR DESCRIPTION
updates cannot be detected When all update models are disabled

pms: Bug-313481