### PR TITLE
fix: update control improvements for battery and disabled states

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -194,10 +194,10 @@ DccObject {
         weight: 50
         pageType: DccObject.Item
         visible: advancedSetting.showDetails
+        enabled: !dccData.model().updateModeDisabled
         page: DccGroupView {
             height: implicitHeight + 10
             spacing: 0
-
         }
         DccObject {
             name: "autoDownload"
@@ -315,6 +315,7 @@ DccObject {
             displayName: qsTr("Updates Notification")
             weight: 10
             pageType: DccObject.Editor
+            enabled: !dccData.model().updateModeDisabled
             page: D.Switch {
                 checked: dccData.model().updateNotify
                 onCheckedChanged: {

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -155,13 +155,19 @@ DccObject {
         backgroundType: DccObject.Normal
         weight: 70
         visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().installFailedListModel.anyVisible
-        enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible
+        enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible && dccData.model().batterIsOK
         pageType: DccObject.Item
 
         page: UpdateControl {
             updateListModels: dccData.model().installFailedListModel
             updateStateIcon: "qrc:/icons/deepin/builtin/icons/warning.svg"
-            updateTitle: qsTr("Installation update failed")
+            updateTitle: {
+                if (!dccData.model().batterIsOK) {
+                    return qsTr("The battery capacity is lower than 60%. To get successful updates, please plug in.")
+                }
+                return qsTr("Installation update failed")
+            }
+
             updateTips: dccData.model().downloadFailedTips
             btnActions: [ qsTr("Continue Update") ]
 
@@ -178,13 +184,20 @@ DccObject {
         backgroundType: DccObject.Normal
         weight: 80
         visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().backupFailedListModel.anyVisible
+        enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible && dccData.model().batterIsOK
         pageType: DccObject.Item
 
         page: UpdateControl {
             updateListModels: dccData.model().backupFailedListModel
             processTitle: qsTr("Backup failed")
             updateTitle: qsTr("Backup failed")
-            updateTips: qsTr("If you continue the updates, you cannot roll back to the old system later.")
+            updateTips: {
+                if (!dccData.model().batterIsOK) {
+                    return qsTr("The battery capacity is lower than 60%. To get successful updates, please plug in.")
+                }
+                return qsTr("If you continue the updates, you cannot roll back to the old system later.")
+            }
+
             btnActions: [ qsTr("Try Again"), qsTr("Proceed to Update") ]
             onBtnClicked: function(index, updateType) {
                 console.log("index: " + index, " updateType: " + updateType)


### PR DESCRIPTION
1. Added battery level check (60% threshold) to enable/disable update controls
2. Added updateModeDisabled check to disable settings when updates are not allowed
3. Improved error messages to show battery warning when level is low
4. Consolidated enable/disable logic across multiple update controls

These changes ensure:
- Updates are blocked when battery is too low (preventing potential issues)
- Settings are properly disabled when update mode is restricted
- Users get clear feedback about battery requirements
- Consistent behavior across different update failure scenarios

fix: 更新控制改进电池和禁用状态处理

1. 添加电池电量检查（60%阈值）来控制更新控件的启用/禁用
2. 添加updateModeDisabled检查以在更新不允许时禁用设置
3. 改进错误消息，在电量低时显示电池警告
4. 统一多个更新控件的启用/禁用逻辑

这些更改确保：
- 电池电量过低时阻止更新（防止潜在问题）
- 更新模式受限时正确禁用设置
- 用户能清楚了解电池电量要求
- 不同更新失败场景下行为一致