### PR TITLE
fix: The switch updated by third-party sources has been reset

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -181,7 +181,7 @@ void UpdateWorker::initConnect()
         }
 
         if (configName == "updateThirdPartySource") {
-            m_model->setThirdPartyUpdateEnabled(IsCommunitySystem ? true : DConfigWatcher::instance()->getValue(DConfigWatcher::update, "updateThirdPartySource").toString() != "Hidden");
+            m_model->setThirdPartyUpdateEnabled(DConfigWatcher::instance()->getValue(DConfigWatcher::update, configName).toString() != "Hidden");
         } else if (configName == "updateSafety") {
             m_model->setSecurityUpdateEnabled(DConfigWatcher::instance()->getValue(DConfigWatcher::update, configName).toString() != "Hidden");
         } else if (configName == "updateHistoryEnabled") {
@@ -206,7 +206,7 @@ void UpdateWorker::activate()
     m_model->setUpdateMode(m_updateInter->updateMode());
     m_model->setCheckUpdateMode(m_updateInter->checkUpdateMode());
     m_model->setSecurityUpdateEnabled(DConfigWatcher::instance()->getValue(DConfigWatcher::update, "updateSafety").toString() != "Hidden");
-    m_model->setThirdPartyUpdateEnabled(IsCommunitySystem ? true : DConfigWatcher::instance()->getValue(DConfigWatcher::update, "updateThirdPartySource").toString() != "Hidden");
+    m_model->setThirdPartyUpdateEnabled(DConfigWatcher::instance()->getValue(DConfigWatcher::update, "updateThirdPartySource").toString() != "Hidden");
     m_model->setSpeedLimitConfig(m_updateInter->downloadSpeedLimitConfig().toUtf8());
     m_model->setAutoDownloadUpdates(m_updateInter->autoDownloadUpdates());
     QString config = m_updateInter->idleDownloadConfig();


### PR DESCRIPTION
Remove redundant `IsCommunitySystem` condition and standardize the third-party update check to rely solely on `DConfigWatcher` for consistency across the codebase. This ensures uniform behavior regardless of the system type.

log: as title
pms: BUG-316683