### PR TITLE
fix: update privacy policy URL handling logic

### DIFF
--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -1073,24 +1073,29 @@ bool UpdateModel::isCommunitySystem() const
 
 QString UpdateModel::privacyAgreementText() const
 {
-    static QStringList supportedRegion = { "cn", "en", "tw", "hk", "ti", "uy" };
-    static QStringList communitySupportRegion = { "cn", "en" };
     const QString& systemLocaleName = QLocale::system().name();
     if (systemLocaleName.length() != QString("zh_CN").length()) {
-        qCWarning(DCC_UPDATE_MODEL) << "Get system locale name failed:" << systemLocaleName;
+        qCDebug(DCC_UPDATE_MODEL) << "Get system locale name failed:" << systemLocaleName;
     }
     QString region = systemLocaleName.right(2).toLower();
 
-    QString addr = "https://www.uniontech.com/agreement/privacy-";
+    QString addr;
     if (DCC_NAMESPACE::IsCommunitySystem) {
-        addr = "https://www.uniontech.com/agreement/deepin-privacy-";
-        if (!communitySupportRegion.contains(region))
+        QString communityRegion = "en";
+        QStringList chineseRegion = { "cn", "hk", "tw" };
+        if (chineseRegion.contains(region)) {
+            communityRegion = "zh";
+        }
+        addr = QString("https://www.deepin.org/%1/agreement/privacy/").arg(communityRegion);
+    } else {
+        QStringList supportedRegion = { "cn", "en", "tw", "hk", "ti", "uy" };
+        if (!supportedRegion.contains(region)) {
             region = "en";
-    } else if (!supportedRegion.contains(region)) {
-        region = "en";
+        }
+        addr = QString("https://www.uniontech.com/agreement/privacy-%1").arg(region);
     }
 
-    QString link = QString("<a style=\"text-decoration: none\" href=\"%1%2\">%3</a>").arg(addr).arg(region).arg(tr("Privacy Policy"));
+    QString link = QString("<a style=\"text-decoration: none\" href=\"%1\">%2</a>").arg(addr).arg(tr("Privacy Policy"));
     return tr("To use this software, you must accept the %1 that accompanies software updates.").arg(link);
 }
 


### PR DESCRIPTION
1. Restructured privacy policy URL generation to handle community and commercial versions separately
2. Simplified URL construction by removing region suffix for community version
3. Added direct Chinese/English URLs for community version (deepin.org)
4. Maintained existing region-based URLs for commercial version (uniontech.com)
5. Improved code readability by removing redundant static lists and simplifying conditionals

The changes ensure proper privacy policy links are generated for different system types and regions, while making the code more maintainable and consistent with the actual privacy policy documentation locations.

fix: 更新隐私政策URL处理逻辑

1. 重构隐私政策URL生成逻辑，区分社区版和商业版处理
2. 简化社区版URL构造，不再使用区域后缀
3. 为社区版添加直接的中文/英文URL（deepin.org）
4. 商业版保持原有的基于区域的URL（uniontech.com）
5. 通过移除冗余静态列表和简化条件判断提高代码可读性

这些修改确保为不同系统类型和区域生成正确的隐私政策链接，同时使代码更易于
维护并与实际隐私政策文档位置保持一致。

pms: Bug-317131