### PR TITLE
fix: improve update module state management

### DIFF
--- a/src/dcc-update-plugin/qml/update.qml
+++ b/src/dcc-update-plugin/qml/update.qml
@@ -11,7 +11,9 @@ import org.deepin.dcc 1.0
 DccObject {
     id: root
 
-    property bool hasHandledChildrenChange: false
+    // 标识当前是否有更新模块视图显示
+    property bool hasView: false
+    // 激活更新模型的信号，用于触发更新检查
     signal activeUpdateModel()
 
     name: "update"
@@ -23,17 +25,14 @@ DccObject {
 
     page: DccRightView{
 
-        // 切换模块时候，控件会重新创建，从而触发检查更新
+        // 当组件创建完成时，设置hasView为true并触发更新检查
         Component.onCompleted: {
+            hasView = true
             activeUpdateModel();
         }
-    }
-
-    // 通过dbus接口直接进入更新模块时，onCompleted已经发送了信号，但其子控件可能还没创建好，需要使用该信号触发检查更新，但只需要触发一次即可
-    onChildrenChanged : {
-        if (!hasHandledChildrenChange) {
-            hasHandledChildrenChange = true
-            activeUpdateModel();
+        // 当组件销毁时，设置hasView为false
+        Component.onDestruction: {
+            hasView = false
         }
     }
 }

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -12,24 +12,36 @@ import org.deepin.dcc.update 1.0
 
 DccObject {
 
+    // 处理更新模块激活和子组件变化的连接
     Connections {
+        // 标识是否已经检查过更新
+        property bool hasCheckUpdate: false
+        
         target: dccModule
+        // 当更新模块被激活时，检查是否需要更新
         function onActiveUpdateModel() {
+            hasCheckUpdate = true
             dccData.work().checkNeedDoUpdates()
         }
-    }
-
-    Connections {
-        target: dccData.model()
-        function onSystemActivationChanged() {
-            if (dccData.model().systemActivation) {
+        // 当子组件发生变化时，如果视图存在且未检查过更新，则进行检查，这里主要适用于dbus直接调起更新模块的情况
+        function onChildrenChanged() {
+            if (dccModule.hasView && !hasCheckUpdate) {
+                hasCheckUpdate = true
                 dccData.work().checkNeedDoUpdates()
             }
         }
     }
 
+    // 处理系统激活状态和更新禁用状态变化的连接
     Connections {
         target: dccData.model()
+        // 当系统激活状态改变时，如果系统已激活则检查更新
+        function onSystemActivationChanged() {
+            if (dccData.model().systemActivation) {
+                dccData.work().checkNeedDoUpdates()
+            }
+        }
+        // 当更新禁用状态改变时，如果更新未被禁用则检查更新
         function onIsUpdateDisabledChanged() {
             if (!dccData.model().isUpdateDisabled) {
                 dccData.work().checkNeedDoUpdates()


### PR DESCRIPTION
1. Replaced hasHandledChildrenChange with more descriptive hasView property
2. Added Component.onDestruction handler to track view lifecycle
3. Consolidated update check logic in updateMain.qml with hasCheckUpdate flag
4. Improved comments explaining the purpose of each signal and property
5. Combined multiple Connections blocks into a single one for better organization

The changes improve the reliability of update checks by:
- Better tracking when the update view is active/inactive
- Preventing duplicate update checks
- Making the code more maintainable with clearer state management
- Handling edge cases when the module is accessed via DBus

fix: 改进更新模块状态管理

1. 用更具描述性的 hasView 属性替换了 hasHandledChildrenChange
2. 添加 Component.onDestruction 处理程序来跟踪视图生命周期
3. 在 updateMain.qml 中使用 hasCheckUpdate 标志统一更新检查逻辑
4. 改进了注释，更清楚地解释每个信号和属性的用途
5. 将多个 Connections 块合并为一个以提高组织性

这些改进通过以下方式提高了更新检查的可靠性：
- 更好地跟踪更新视图的激活/非激活状态
- 防止重复的更新检查
- 通过更清晰的状态管理使代码更易于维护
- 处理通过 DBus 访问模块时的边缘情况

pms: Bug-316589