### PR TITLE
fix: improve update status handling and UI logic

### DIFF
--- a/src/dcc-update-plugin/operation/common.h
+++ b/src/dcc-update-plugin/operation/common.h
@@ -55,11 +55,6 @@ enum UpdatesStatus {
     UpgradeFailed,
     UpgradeSuccess,
     UpgradeComplete,
-
-    // 非真实更新状态，可随系统配置变化
-    SystemIsNotActive,
-    UpdateIsDisabled,
-    AllUpdateModeDisabled
 };
 Q_ENUM_NS(UpdatesStatus)
 

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -21,8 +21,11 @@ class UpdateModel : public QObject
 {
     Q_OBJECT
 
+    Q_PROPERTY(bool updateProhibited READ updateProhibited NOTIFY updateProhibitedChanged FINAL)
+    Q_PROPERTY(bool systemActivation READ systemActivation NOTIFY systemActivationChanged FINAL)
     Q_PROPERTY(bool isUpdateDisabled READ isUpdateDisabled NOTIFY isUpdateDisabledChanged FINAL)
-    Q_PROPERTY(bool systemActivation READ systemActivation WRITE setSystemActivation NOTIFY systemActivationChanged FINAL)
+    Q_PROPERTY(QString updateDisabledIcon READ updateDisabledIcon NOTIFY updateDisabledIconChanged FINAL)
+    Q_PROPERTY(QString updateDisabledTips READ updateDisabledTips NOTIFY updateDisabledTipsChanged FINAL)
     Q_PROPERTY(bool batterIsOK READ batterIsOK NOTIFY batterIsOKChanged FINAL)
     Q_PROPERTY(int lastStatus READ lastStatus  NOTIFY lastStatusChanged FINAL)
 
@@ -87,11 +90,22 @@ public:
     int lastoreDaemonStatus() const { return m_lastoreDaemonStatus; }
     void setLastoreDaemonStatus(int status);
 
-    bool isUpdateDisabled() const { return m_isUpdateDisabled; }
-    void setIsUpdateDisabled(bool disabled);
+    bool updateProhibited() const { return m_updateProhibited; }
+    void setUpdateProhibited(bool prohibited);
 
     bool systemActivation() const { return m_systemActivation; }
     void setSystemActivation(bool systemActivation);
+    
+    void refreshIsUpdateDisabled();
+
+    bool isUpdateDisabled() const { return m_isUpdateDisabled; }
+    void setIsUpdateDisabled(bool disabled);
+
+    QString updateDisabledIcon() const { return m_updateDisabledIcon; }
+    void setUpdateDisabledIcon(const QString &icon);
+
+    QString updateDisabledTips() const { return m_updateDisabledTips; }
+    void setUpdateDisabledTips(const QString &tips);
 
     bool batterIsOK() const { return m_batterIsOK; }
     void setBatterIsOK(bool ok);
@@ -295,8 +309,11 @@ public slots:
                                    const QStringList &invalidatedProperties);
 
 Q_SIGNALS:
-    void isUpdateDisabledChanged(bool isDisabled);
+    void updateProhibitedChanged(bool prohibited);
     void systemActivationChanged(bool systemActivation);
+    void isUpdateDisabledChanged(bool isDisabled);
+    void updateDisabledIconChanged();
+    void updateDisabledTipsChanged();
 
     void batterIsOKChanged(bool isOK);
     void lastStatusChanged(int status);
@@ -363,8 +380,11 @@ Q_SIGNALS:
 
 private:
     int m_lastoreDaemonStatus; // 比较重要的数值，每个位标识不同的含义，使用 LastoreDaemonDConfigStatusHelper 对它进行解析
-    bool m_isUpdateDisabled;
+    bool m_updateProhibited;
     bool m_systemActivation;
+    bool m_isUpdateDisabled;
+    QString m_updateDisabledIcon;
+    QString m_updateDisabledTips;
     bool m_batterIsOK;
     int m_lastStatus;
 

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -370,14 +370,7 @@ void UpdateWorker::checkNeedDoUpdates()
 {
     qCInfo(DCC_UPDATE_WORKER) << "check need do updates";
 
-    if (m_model->updateModeDisabled()) {
-        m_model->setShowCheckUpdate(true);
-        m_model->setCheckUpdateStatus(UpdatesStatus::AllUpdateModeDisabled);
-        return;
-    }
-
-    if (m_model->isUpdateDisabled() || !m_model->systemActivation()) {
-        qCDebug(DCC_UPDATE_WORKER) << "update disabled:" << m_model->isUpdateDisabled() << " system activation:" << m_model->systemActivation();
+    if (m_model->isUpdateDisabled()) {
         m_model->setShowCheckUpdate(false);
         return;
     }

--- a/src/dcc-update-plugin/qml/UpdateDisable.qml
+++ b/src/dcc-update-plugin/qml/UpdateDisable.qml
@@ -12,7 +12,7 @@ ColumnLayout {
 
     Rectangle {
         Layout.fillWidth: true
-        Layout.preferredHeight: 500
+        Layout.preferredHeight: dccData.model().systemActivation ? 338 : 500
 
         color: "transparent"
         clip: true
@@ -23,7 +23,7 @@ ColumnLayout {
 
             Image {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                source: dccData.model().isUpdateDisabled ? "update_prohibit" : "update_no_active"     
+                source: dccData.model().updateDisabledIcon
                 height: 140
             }
 
@@ -31,8 +31,7 @@ ColumnLayout {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 width: implicitWidth
                 height: 30
-                text: dccData.model().isUpdateDisabled ? qsTr("The system updates are disabled. Please contact your administrator for help")
-                                                       : qsTr("Your system is not activated, and it failed to connect to update services")
+                text: dccData.model().updateDisabledTips
                 font.pixelSize: 12
             }
         }

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -23,6 +23,7 @@ DccObject {
     }
 
     DccObject {
+        id: updateTypeGrp
         name: "updateTypeGrp"
         parentName: "updateSettingsPage"
         weight: 20
@@ -33,11 +34,12 @@ DccObject {
         }
 
         // 下载、备份和安装过程中，按钮置灰不可用
-        enabled: !dccData.model().downloadWaiting && 
-                 !dccData.model().upgradeWaiting && 
-                 !dccData.model().installinglistModel.anyVisible && 
-                 !dccData.model().backingUpListModel.anyVisible && 
-                 !dccData.model().downloadinglistModel.anyVisible
+        property bool editorEnabled: !dccData.model().downloadWaiting && 
+                                     !dccData.model().upgradeWaiting && 
+                                     !dccData.model().installinglistModel.anyVisible && 
+                                     !dccData.model().backingUpListModel.anyVisible && 
+                                     !dccData.model().downloadinglistModel.anyVisible &&
+                                     !dccData.model().updateProhibited
 
         DccObject {
             name: "functionUpdate"
@@ -45,6 +47,7 @@ DccObject {
             displayName: qsTr("Function Updates")
             description: qsTr("Delivers a cumulative update including new features, quality updates, and  security updates")
             weight: 10
+            enabled: updateTypeGrp.editorEnabled
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().functionUpdate
@@ -60,6 +63,7 @@ DccObject {
             description: qsTr("Delivers security updates")
             weight: 20
             visible: dccData.model().securityUpdateEnabled && !dccData.model().isCommunitySystem()
+            enabled: updateTypeGrp.editorEnabled
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().securityUpdate
@@ -75,6 +79,7 @@ DccObject {
             description: qsTr("Delivers  updates for additional repository sources")
             weight: 30
             visible: dccData.model().thirdPartyUpdateEnabled
+            enabled: updateTypeGrp.editorEnabled
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().thirdPartyUpdate
@@ -153,6 +158,7 @@ DccObject {
             parentName: "downloadLimitGrp"
             displayName: qsTr("Limit Speed")
             weight: 10
+            enabled: !dccData.model().updateProhibited
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().downloadSpeedLimitEnabled
@@ -168,6 +174,7 @@ DccObject {
             displayName: qsTr("Limit Setting")
             visible: dccData.model().downloadSpeedLimitEnabled
             weight: 20
+            enabled: !dccData.model().updateProhibited
             pageType: DccObject.Editor
             page: RowLayout {
                 D.LineEdit {
@@ -194,7 +201,6 @@ DccObject {
         weight: 50
         pageType: DccObject.Item
         visible: advancedSetting.showDetails
-        enabled: !dccData.model().updateModeDisabled
         page: DccGroupView {
             height: implicitHeight + 10
             spacing: 0
@@ -205,6 +211,7 @@ DccObject {
             displayName: qsTr("Auto Download")
             description: qsTr("Enabling \"Auto Download Updates\" will automatically download updates when connected to the internet")
             weight: 10
+            enabled: !dccData.model().updateProhibited && !dccData.model().updateModeDisabled
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().autoDownloadUpdates
@@ -220,6 +227,7 @@ DccObject {
             displayName: qsTr("Download when Inactive")
             visible: dccData.model().autoDownloadUpdates
             weight: 20
+            enabled: !dccData.model().updateProhibited && !dccData.model().updateModeDisabled
             pageType: DccObject.Item
             page: RowLayout {
                 D.CheckBox {
@@ -315,7 +323,7 @@ DccObject {
             displayName: qsTr("Updates Notification")
             weight: 10
             pageType: DccObject.Editor
-            enabled: !dccData.model().updateModeDisabled
+            enabled: !dccData.model().updateProhibited && !dccData.model().updateModeDisabled
             page: D.Switch {
                 checked: dccData.model().updateNotify
                 onCheckedChanged: {
@@ -385,6 +393,7 @@ DccObject {
             parentName: "mirrorSettingGrp"
             displayName: qsTr("Smart Mirror Switch")
             weight: 10
+            enabled: !dccData.model().updateProhibited
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model().smartMirrorSwitch
@@ -400,6 +409,7 @@ DccObject {
             parentName: "mirrorSettingGrp"
          //   displayName: qsTr("默认镜像源")
             weight: 20
+            enabled: !dccData.model().updateProhibited
             pageType: DccObject.Editor
             page: D.ComboBox {
                 model:["[SG]Ox.sg", "[AU]JAARNET", "[SE]Academic Computer Club", "[CN]阿里云"]
@@ -442,7 +452,7 @@ DccObject {
 
             Connections {
                 target: dccData.work()
-                onRequestCloseTestingChannel: {
+                function onRequestCloseTestingChannel() {
                     ctcloader.active = true
                 }
             }

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -35,15 +35,9 @@ DccObject {
     // 处理系统激活状态和更新禁用状态变化的连接
     Connections {
         target: dccData.model()
-        // 当系统激活状态改变时，如果系统已激活则检查更新
-        function onSystemActivationChanged() {
-            if (dccData.model().systemActivation) {
-                dccData.work().checkNeedDoUpdates()
-            }
-        }
         // 当更新禁用状态改变时，如果更新未被禁用则检查更新
         function onIsUpdateDisabledChanged() {
-            if (!dccData.model().isUpdateDisabled) {
+            if (dccModule.hasView && !dccData.model().isUpdateDisabled) {
                 dccData.work().checkNeedDoUpdates()
             }
         }
@@ -54,9 +48,9 @@ DccObject {
         name: "updateDisable"
         parentName: "update"
         pageType: DccObject.Item
-        backgroundType: DccObject.AutoBg
+        backgroundType: dccData.model().systemActivation ? DccObject.Normal : DccObject.AutoBg
         weight: 10
-        visible: !dccData.model().systemActivation || dccData.model().isUpdateDisabled
+        visible: dccData.model().isUpdateDisabled
         page: UpdateDisable {}
     }
 
@@ -65,7 +59,7 @@ DccObject {
         parentName: "update"
         pageType: DccObject.Item
         backgroundType: DccObject.Normal
-        visible: (updateDisable && !updateDisable.visible) && dccData.model().showCheckUpdate
+        visible: !dccData.model().isUpdateDisabled && dccData.model().showCheckUpdate
         weight: 20
         page: CheckUpdate {}
     }
@@ -76,7 +70,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 30
-        visible: (updateDisable && !updateDisable.visible)  && !dccData.model().showCheckUpdate && dccData.model().installinglistModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled  && !dccData.model().showCheckUpdate && dccData.model().installinglistModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -95,7 +89,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 40
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().backingUpListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().backingUpListModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -114,7 +108,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 50
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().downloadinglistModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().downloadinglistModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -142,7 +136,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 60
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().installCompleteListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().installCompleteListModel.anyVisible
         pageType: DccObject.Item
 
         page: UpdateControl {
@@ -164,7 +158,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 70
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().installFailedListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().installFailedListModel.anyVisible
         enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible && dccData.model().batterIsOK
         pageType: DccObject.Item
 
@@ -193,7 +187,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 80
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().backupFailedListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().backupFailedListModel.anyVisible
         enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible && dccData.model().batterIsOK
         pageType: DccObject.Item
 
@@ -226,7 +220,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 90
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().preInstallListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().preInstallListModel.anyVisible
         enabled: !dccData.model().backingUpListModel.anyVisible && !dccData.model().installinglistModel.anyVisible && dccData.model().batterIsOK
         pageType: DccObject.Item
 
@@ -255,7 +249,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 100
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().downloadFailedListModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().downloadFailedListModel.anyVisible
         enabled: !dccData.model().downloadinglistModel.anyVisible
         pageType: DccObject.Item
 
@@ -279,7 +273,7 @@ DccObject {
         parentName: "update"
         backgroundType: DccObject.Normal
         weight: 110
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate && dccData.model().preUpdatelistModel.anyVisible
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate && dccData.model().preUpdatelistModel.anyVisible
         enabled: !dccData.model().downloadinglistModel.anyVisible
         pageType: DccObject.Item
 
@@ -305,7 +299,7 @@ DccObject {
         description: qsTr("Configure Update settings、Security Updates、Auto Download Updates and Updates Notification")
         icon: "update_set"
         weight: 120
-        visible: updateDisable && !updateDisable.visible
+        visible: dccData.model().systemActivation
 
         UpdateSetting {}
     }
@@ -316,7 +310,7 @@ DccObject {
         parentName: "update"
         weight: 1000
         backgroundType: DccObject.Normal
-        visible: (updateDisable && !updateDisable.visible) && !dccData.model().showCheckUpdate
+        visible: !dccData.model().isUpdateDisabled && !dccData.model().showCheckUpdate
         pageType: DccObject.Item
 
         page: RowLayout {

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Surt</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Les actualitzacions del sistema estan desactivades. Poseu-vos en contacte amb l&apos;administrador per obtenir ajuda.</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>El sistema no està activat i no s&apos;ha pogut connectar per actualitzar-ne els serveis.</translation>
     </message>
 </context>
 <context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Activeu els interruptors a Actualitza el contingut per obtenir-ne una experiència millor.</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>El sistema no està activat i no s&apos;ha pogut connectar per actualitzar-ne els serveis.</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Les actualitzacions del sistema estan desactivades. Poseu-vos en contacte amb l&apos;administrador per obtenir ajuda.</translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -22,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -40,7 +31,7 @@
     </message>
     <message>
         <source>No update history</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Updates</source>
@@ -52,7 +43,7 @@
     </message>
     <message>
         <source>Delivers a cumulative update including new features, quality updates, and security updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers security updates</source>
@@ -60,7 +51,7 @@
     </message>
     <message>
         <source>Installation date:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -216,15 +207,23 @@
     </message>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -319,11 +318,11 @@
     </message>
     <message>
         <source>Expand</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -448,15 +447,15 @@
     </message>
     <message>
         <source>Try Again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Proceed to Update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The battery capacity is lower than 60%. To get successful updates, please plug in.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -22,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Las actualizaciones del sistema están desactivadas. Póngase en contacto con su administrador para obtener ayuda.</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Su sistema no está activado y no ha podido conectarse a los servicios de actualización</translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -40,7 +31,7 @@
     </message>
     <message>
         <source>No update history</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Updates</source>
@@ -52,7 +43,7 @@
     </message>
     <message>
         <source>Delivers a cumulative update including new features, quality updates, and security updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers security updates</source>
@@ -60,7 +51,7 @@
     </message>
     <message>
         <source>Installation date:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -224,7 +215,15 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Su sistema no está activado y no ha podido conectarse a los servicios de actualización</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Las actualizaciones del sistema están desactivadas. Póngase en contacto con su administrador para obtener ayuda.</translation>
     </message>
 </context>
 <context>
@@ -323,7 +322,7 @@
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -456,7 +455,7 @@
     </message>
     <message>
         <source>The battery capacity is lower than 60%. To get successful updates, please plug in.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Poistu</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Päivitykset ovat poistettu käytöstä. Pyydä apua järjestelmänvalvojaltasi.</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Tietokonetta ei ole aktivoitu, eikä se onnistu saamaan yhteyttä päivityspalveluihin.</translation>
     </message>
 </context>
 <context>
@@ -226,6 +217,14 @@
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Ota käyttöön &quot;Päivitä sisältö&quot; kytkimet saadaksesi paremman kokemuksen</translation>
     </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Tietokonetta ei ole aktivoitu, eikä se onnistu saamaan yhteyttä päivityspalveluihin.</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Päivitykset ovat poistettu käytöstä. Pyydä apua järjestelmänvalvojaltasi.</translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>
@@ -323,7 +322,7 @@
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lt">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lt">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -10,7 +12,7 @@
     <name>QuitTestingChannelDialog</name>
     <message>
         <source>If you exit the beta program, you will no longer receive beta updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -18,29 +20,18 @@
     </message>
     <message>
         <source>Exit</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Atnaujinimų istorija</translation>
     </message>
     <message>
         <source>No update history</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Updates</source>
@@ -52,7 +43,7 @@
     </message>
     <message>
         <source>Delivers a cumulative update including new features, quality updates, and security updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers security updates</source>
@@ -60,7 +51,7 @@
     </message>
     <message>
         <source>Installation date:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -79,66 +70,66 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogHelper</name>
     <message>
         <source>NONE</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>LOW</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>MEDIUM</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>HIGH</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>CRITICAL</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>critical-risk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>high-risk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>medium-risk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>low-risk</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This update fixes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>vulnerabilities</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>vulnerability</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 of %2 %3</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>`数字+%`会在代码中替换为字符串，例如：3 of high-risk vulnerabilities；各语言需要根据实际情况增加空格(例如：中文没有空格，英文有空格)</extra-content_explain>
     </message>
     <message>
@@ -168,31 +159,31 @@
     </message>
     <message>
         <source>Downloading updates failed. Please free up %1 disk space first.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dependency error, failed to detect the updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please check your network and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Downloading updates failed. Please check your network and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unable to perform system backup. If you continue the updates, you cannot roll back to the old system later.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>If you continue the updates, you cannot roll back to the old system later.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Insufficient disk space</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>DPKG error</source>
@@ -204,46 +195,54 @@
     </message>
     <message>
         <source>Service connection is abnormal, please check the network and try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The repository source configuration is not valid, please check and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Check Again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use this software, you must accept the %1 that accompanies software updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateSetting</name>
     <message>
         <source>Smart Mirror Switch</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Function Updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers a cumulative update including new features, quality updates, and  security updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Security Updates</source>
@@ -259,15 +258,15 @@
     </message>
     <message>
         <source>Delivers  updates for additional repository sources</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit Setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto Download</source>
@@ -275,19 +274,19 @@
     </message>
     <message>
         <source>Enabling &quot;Auto Download Updates&quot; will automatically download updates when connected to the internet</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Download when Inactive</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start at</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>End at</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Advanced Settings</source>
@@ -295,7 +294,7 @@
     </message>
     <message>
         <source>Updates Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear Package Cache</source>
@@ -311,19 +310,19 @@
     </message>
     <message>
         <source>Join Internal Testing Channel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click here to complete the application</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Expand</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -334,7 +333,7 @@
     </message>
     <message>
         <source>Fixed some known bugs and security vulnerabilities</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Security Updates</source>
@@ -392,7 +391,7 @@
     </message>
     <message>
         <source>Configure Update settings、Security Updates、Auto Download Updates and Updates Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reboot now</source>
@@ -412,7 +411,7 @@
     </message>
     <message>
         <source>Continue Update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Updates Available</source>
@@ -420,23 +419,23 @@
     </message>
     <message>
         <source>Installation update failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To ensure proper functioning of your system and applications, please restart your computer after the update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Backing up in progress...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Backing up in progress</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update installation successful</source>
@@ -444,19 +443,19 @@
     </message>
     <message>
         <source>If you continue the updates, you cannot roll back to the old system later.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Try Again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Proceed to Update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The battery capacity is lower than 60%. To get successful updates, please plug in.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Afsluiten</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Systeemupdates zijn uitgeschakeld. Neem contact op met je systeembeheerder.</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Er kan geen verbinding worden gemaakt, omdat je systeem niet is geactiveerd.</translation>
     </message>
 </context>
 <context>
@@ -226,6 +217,14 @@
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Schakel de opties onder ‘Update-inhoud’ in om de gebruikservaring te verbeteren</translation>
     </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Er kan geen verbinding worden gemaakt, omdat je systeem niet is geactiveerd.</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Systeemupdates zijn uitgeschakeld. Neem contact op met je systeembeheerder.</translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>
@@ -323,7 +322,7 @@
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Wyjdź</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Aktualizacje systemowe są wyłączone. Skontaktuj się z administratorem, aby uzyskać pomoc</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Twój system nie jest aktywowany i nie udało mu się połączyć z usługą aktualizacji</translation>
     </message>
 </context>
 <context>
@@ -226,6 +217,14 @@
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Sprawdź ustawienia, aby usprawnić proces aktualizacji</translation>
     </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Twój system nie jest aktywowany i nie udało mu się połączyć z usługą aktualizacji</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Aktualizacje systemowe są wyłączone. Skontaktuj się z administratorem, aby uzyskać pomoc</translation>
+    </message>
 </context>
 <context>
     <name>UpdateSetting</name>
@@ -323,7 +322,7 @@
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Sair</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>As atualizações do sistema estão desativadas. Por favor, entre em contato com o administrador para obter ajuda.</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Seu sistema não está ativado e não conseguiu conectar aos serviços de atualização.</translation>
     </message>
 </context>
 <context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Ative os interruptores em Conteúdo da Atualização para obter uma melhor experiência</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Seu sistema não está ativado e não conseguiu conectar aos serviços de atualização.</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>As atualizações do sistema estão desativadas. Por favor, entre em contato com o administrador para obter ajuda.</translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>Dilni</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>Përditësimet e sistemit janë të çaktivizuara. Ju lutemi, për ndihmë, lidhuni me përgjegjësin tuaj</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>Sistemi juaj s’është aktivizuar dhe s’u arrit të lidhej me shërbime përditësimesh</translation>
     </message>
 </context>
 <context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>Për të pasur punim më të mirë, hapni çelësat që gjenden nën Lëndë Përditësimi</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>Sistemi juaj s’është aktivizuar dhe s’u arrit të lidhej me shërbime përditësimesh</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>Përditësimet e sistemit janë të çaktivizuara. Ju lutemi, për ndihmë, lidhuni me përgjegjësin tuaj</translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -22,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -40,7 +31,7 @@
     </message>
     <message>
         <source>No update history</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Updates</source>
@@ -48,11 +39,11 @@
     </message>
     <message>
         <source>Security Updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers a cumulative update including new features, quality updates, and security updates</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delivers security updates</source>
@@ -60,7 +51,7 @@
     </message>
     <message>
         <source>Installation date:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -224,7 +215,15 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -323,7 +322,7 @@
     </message>
     <message>
         <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -456,7 +455,7 @@
     </message>
     <message>
         <source>The battery capacity is lower than 60%. To get successful updates, please plug in.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -24,17 +24,6 @@
     </message>
 </context>
 <context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>UpdateHistoryDialog</name>
     <message>
         <source>Update History</source>
@@ -226,6 +215,14 @@
     </message>
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>退 出</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>系统已被禁止更新，请联系管理员！</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>当前系统未激活，无法启动更新服务</translation>
     </message>
 </context>
 <context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>开启更新内容开关，可以获得更优质的功能体验哦</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>当前系统未激活，无法启动更新服务</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>系统已被禁止更新，请联系管理员！</translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>退 出</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>系統已被禁止更新，請聯繫管理員！</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>當前系統未激活，無法啓動更新服務</translation>
     </message>
 </context>
 <context>
@@ -143,12 +134,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>開啓更新內容開關，可以獲得更優質的功能體驗哦</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>當前系統未激活，無法啓動更新服務</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>系統已被禁止更新，請聯繫管理員！</translation>
     </message>
 </context>
 <context>
@@ -376,7 +375,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -19,17 +21,6 @@
     <message>
         <source>Exit</source>
         <translation>退 出</translation>
-    </message>
-</context>
-<context>
-    <name>UpdateDisable</name>
-    <message>
-        <source>The system updates are disabled. Please contact your administrator for help</source>
-        <translation>系統已被禁止更新，請聯絡管理員！</translation>
-    </message>
-    <message>
-        <source>Your system is not activated, and it failed to connect to update services</source>
-        <translation>當前系統未啟用，無法啟動更新服務</translation>
     </message>
 </context>
 <context>
@@ -143,12 +134,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -225,6 +216,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>開啟更新內容開關，可以獲得更優質的功能體驗哦</translation>
+    </message>
+    <message>
+        <source>Your system is not activated, and it failed to connect to update services</source>
+        <translation>當前系統未啟用，無法啟動更新服務</translation>
+    </message>
+    <message>
+        <source>The system updates are disabled. Please contact your administrator for help</source>
+        <translation>系統已被禁止更新，請聯絡管理員！</translation>
     </message>
 </context>
 <context>
@@ -376,7 +375,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>


### PR DESCRIPTION
1. Removed unused enum values (SystemIsNotActive, UpdateIsDisabled, AllUpdateModeDisabled) from UpdatesStatus
2. Added new properties (updateProhibited, updateDisabledIcon, updateDisabledTips) to UpdateModel for better status management
3. Implemented refreshIsUpdateDisabled() to centralize disabled state logic with different scenarios (system activation, update prohibition, update mode)
4. Updated QML components to use new properties and simplified visibility logic
5. Consolidated translation strings by removing duplicate messages from UpdateDisable context
6. Improved UI responsiveness by properly handling update prohibition states in settings

fix: 改进更新状态处理和UI逻辑

1. 从UpdatesStatus中移除未使用的枚举值(SystemIsNotActive, UpdateIsDisabled, AllUpdateModeDisabled)
2. 在UpdateModel中添加新属性(updateProhibited, updateDisabledIcon, updateDisabledTips)以更好管理状态
3. 实现refreshIsUpdateDisabled()集中处理禁用状态逻辑(系统激活、更新禁 止、更新模式)
4. 更新QML组件使用新属性并简化可见性逻辑
5. 通过移除UpdateDisable上下文中的重复消息来合并翻译字符串
6. 通过在设置中正确处理更新禁止状态来改进UI响应性

pms: Bug-313527
pms: Bug-316781