### PR TITLE
fix: use DccTimeRange component instead of SpinBox

### DIFF
--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -968,16 +968,14 @@ bool UpdateModel::idleDownloadEnabled() const
     return m_idleDownloadConfig.idleDownloadEnabled;
 }
 
-int UpdateModel::beginTime() const
+QString UpdateModel::beginTime() const
 {
-    QTime time = QTime::fromString(m_idleDownloadConfig.beginTime);
-    return time.hour() * 60 + time.minute();
+    return m_idleDownloadConfig.beginTime;
 }
 
-int UpdateModel::endTime() const
+QString UpdateModel::endTime() const
 {
-    QTime time = QTime::fromString(m_idleDownloadConfig.endTime);
-    return time.hour() * 60 + time.minute();
+    return m_idleDownloadConfig.endTime;
 }
 
 void UpdateModel::setIdleDownloadConfig(const IdleDownloadConfig& config)

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -72,8 +72,8 @@ class UpdateModel : public QObject
     Q_PROPERTY(QString downloadSpeedLimitSize READ downloadSpeedLimitSize NOTIFY downloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool autoDownloadUpdates READ autoDownloadUpdates WRITE setAutoDownloadUpdates NOTIFY autoDownloadUpdatesChanged FINAL)
     Q_PROPERTY(bool idleDownloadEnabled READ idleDownloadEnabled NOTIFY idleDownloadConfigChanged FINAL)
-    Q_PROPERTY(int beginTime READ beginTime NOTIFY idleDownloadConfigChanged FINAL)
-    Q_PROPERTY(int endTime READ endTime NOTIFY idleDownloadConfigChanged FINAL)
+    Q_PROPERTY(QString beginTime READ beginTime NOTIFY idleDownloadConfigChanged FINAL)
+    Q_PROPERTY(QString endTime READ endTime NOTIFY idleDownloadConfigChanged FINAL)
     Q_PROPERTY(bool updateNotify READ updateNotify WRITE setUpdateNotify NOTIFY updateNotifyChanged FINAL)
     Q_PROPERTY(bool autoCleanCache READ autoCleanCache WRITE setAutoCleanCache NOTIFY autoCleanCacheChanged FINAL)
     Q_PROPERTY(bool smartMirrorSwitch READ smartMirrorSwitch WRITE setSmartMirrorSwitch NOTIFY smartMirrorSwitchChanged FINAL)
@@ -253,8 +253,8 @@ public:
     void setAutoDownloadUpdates(bool autoDownloadUpdates);
 
     bool idleDownloadEnabled() const;
-    int beginTime() const;
-    int endTime() const;
+    QString beginTime() const;
+    QString endTime() const;
     IdleDownloadConfig idleDownloadConfig() const { return m_idleDownloadConfig; }
     void setIdleDownloadConfig(const IdleDownloadConfig &config);
 

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -67,10 +67,9 @@ public:
     void setDownloadSpeedLimitConfig(const QString& config);
     Q_INVOKABLE void setAutoDownloadUpdates(const bool& autoDownload);
     Q_INVOKABLE void setIdleDownloadEnabled(bool enable);
-    Q_INVOKABLE void setIdleDownloadBeginTime(int time);
-    Q_INVOKABLE void setIdleDownloadEndTime(int time);
+    Q_INVOKABLE void setIdleDownloadBeginTime(QString time);
+    Q_INVOKABLE void setIdleDownloadEndTime(QString time);
     void setIdleDownloadConfig(const IdleDownloadConfig& config);
-    QString timeToString(int value);
     QString adjustTimeFunc(const QString& start, const QString& end, bool returnEndTime);
 
     // 更新设置-更新提醒

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -258,22 +258,13 @@ DccObject {
                        enabled: inactiveDownloadCheckBox.checked
                     }
 
-                    D.SpinBox {
-                        value: dccData.model().beginTime
-                        from: 0
-                        to: 1440
-                        implicitWidth: 80
-                        font.pixelSize: 14
+                    DccTimeRange {
+                        id: beginTimeRange
                         enabled: inactiveDownloadCheckBox.checked
-                        textFromValue: function (value, locale) {
-                            var time = Math.floor(value / 60)
-                            var timeStr = time < 10 ? ("0" + time.toString()) : time.toString()
-                            var minute =  value % 60
-                            var minuteStr = minute < 10 ? ("0" + minute.toString()) : minute.toString()
-                            return timeStr + ":"+ minuteStr
-                        }
-                        onValueChanged: function() {
-                            dccData.work().setIdleDownloadBeginTime(value)
+                        hour: dccData.model().beginTime.split(':')[0]
+                        minute: dccData.model().beginTime.split(':')[1]
+                        onTimeChanged: {
+                            dccData.work().setIdleDownloadBeginTime(beginTimeRange.timeString)
                         }
                     }
 
@@ -283,22 +274,13 @@ DccObject {
                         enabled: inactiveDownloadCheckBox.checked
                     }
 
-                    D.SpinBox {
-                        value: dccData.model().endTime
-                        implicitWidth: 80
-                        from: 0
-                        to: 1439
-                        font.pixelSize: 14
+                    DccTimeRange {
+                        id: endTimeRange
                         enabled: inactiveDownloadCheckBox.checked
-                        textFromValue: function (value, locale) {
-                            var time = Math.floor(value / 60)
-                            var timeStr = time < 10 ? ("0" + time.toString()) : time.toString()
-                            var minute =  value % 60
-                            var minuteStr = minute < 10 ? ("0" + minute.toString()) : minute.toString()
-                            return timeStr + ":"+ minuteStr
-                        }
-                        onValueChanged: function() {
-                            dccData.work().setIdleDownloadEndTime(value)
+                        hour: dccData.model().endTime.split(':')[0]
+                        minute: dccData.model().endTime.split(':')[1]
+                        onTimeChanged: {
+                            dccData.work().setIdleDownloadEndTime(endTimeRange.timeString)
                         }
                     }
                 }


### PR DESCRIPTION
1. Changed time representation from minutes (int) to string format (HH:MM) in UpdateModel
2. Removed time conversion functions in UpdateWorker since no longer needed
3. Updated QML to use new DccTimeRange component instead of SpinBox
4. Added immediate model update before DBus call to improve UI responsiveness

The changes simplify time handling by using string format directly instead of converting between minutes and time strings. This makes the code more straightforward and removes unnecessary conversion logic. The immediate model update before DBus call improves user experience by making UI changes appear instantly.

fix: 使用 DccTimeRange 组件替代 SpinBox

1. 在 UpdateModel 中将时间表示从分钟数(int)改为字符串格式(HH:MM)
2. 移除了 UpdateWorker 中不再需要的时间转换函数
3. 更新 QML 使用新的 DccTimeRange 组件替代 SpinBox
4. 在 DBus 调用前添加立即模型更新以提高界面响应速度

这些修改通过直接使用字符串格式简化了时间处理，不再需要在分钟数和时间字符
串之间转换。代码变得更直接，移除了不必要的转换逻辑。在 DBus 调用前立即更
新模型改善了用户体验，使界面变化能够即时显示。