### PR TITLE
fix: enable clear button in download speed limit input

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -183,7 +183,7 @@ DccObject {
                     validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
                     alertText: qsTr("Only numbers between 1-99999 are allowed")
                     alertDuration: 3000
-
+                    clearButton.active: lineEdit.activeFocus && (text.length !== 0)
                     text: dccData.model().downloadSpeedLimitSize
 
                     onTextChanged: {


### PR DESCRIPTION
Added clearButton.active property to show clear button only when input is focused and contains text

fix: 在下载速度限制输入中启用清除按钮

 添加 clearButton.active 属性，仅在输入框获得焦点且包含文本时显示清除
按钮