### PR TITLE
chore: fix compilation warnings

### DIFF
--- a/src/dde-abrecovery/main.cpp
+++ b/src/dde-abrecovery/main.cpp
@@ -22,7 +22,10 @@ int main(int argc, char *argv[])
     a.setQuitOnLastWindowClosed(false);
 
     QTranslator translator;
-    translator.load("/usr/share/deepin-update-ui/translations/dde-rollback_" + getCurrentLocale());
+    if (!translator.load("/usr/share/deepin-update-ui/translations/dde-rollback_" + getCurrentLocale())) {
+        qWarning() << "Failed to load translation file for locale" << getCurrentLocale();
+    }
+
     a.installTranslator(&translator);
 
     DLogManager::registerConsoleAppender();

--- a/src/dde-update/checksystemwidget.cpp
+++ b/src/dde-update/checksystemwidget.cpp
@@ -222,7 +222,7 @@ ErrorFrame::ErrorFrame(QWidget *parent)
 
     m_buttonSpacer->changeSize(0, 0);
     m_titleSpacer->changeSize(0, 0);
-    m_iconLabel->setPixmap(DHiDPIHelper::loadNxPixmap(":img/failed.svg"));
+    m_iconLabel->setPixmap(DIcon::loadNxPixmap(":img/failed.svg"));
     const QList<UpdateModel::UpdateAction> actions = {{UpdateModel::Reboot, UpdateModel::EnterDesktop}};
     m_title->setText(tr("Checked for some errors"));
 

--- a/src/dde-update/main.cpp
+++ b/src/dde-update/main.cpp
@@ -30,7 +30,6 @@ int main(int argc, char *argv[])
 
     // qt默认当最后一个窗口析构后，会自动退出程序，这里设置成false，防止插拔时，没有屏幕，导致进程退出
     QApplication::setQuitOnLastWindowClosed(false);
-    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 
     DApplication *app = nullptr;
 #if (DTK_VERSION < DTK_VERSION_CHECK(5, 4, 0, 0))
@@ -41,8 +40,6 @@ int main(int argc, char *argv[])
 
     // qt默认当最后一个窗口析构后，会自动退出程序，这里设置成false，防止插拔时，没有屏幕，导致进程退出
     QApplication::setQuitOnLastWindowClosed(false);
-    //解决Qt在Retina屏幕上图片模糊问题
-    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->setOrganizationName("deepin");
     app->setApplicationName("dde-update");
     app->setApplicationVersion("2015.1.0");
@@ -84,7 +81,10 @@ int main(int argc, char *argv[])
     DGuiApplicationHelper::instance()->setApplicationPalette(pa);
 
     QTranslator translatorLanguage;
-    translatorLanguage.load("/usr/share/deepin-update-ui/translations/dde-update_" + getCurrentLocale());
+    if (!translatorLanguage.load("/usr/share/deepin-update-ui/translations/dde-update_" + getCurrentLocale())) {
+        qWarning() << "Failed to load translation file for locale" << getCurrentLocale();
+    }
+
     app->installTranslator(&translatorLanguage);
 
     UpdateWorker::instance()->init();


### PR DESCRIPTION
1. Added error handling for translation file loading in both main.cpp files
2. Removed redundant Qt::AA_UseHighDpiPixmaps attribute setting
3. Replaced DHiDPIHelper::loadNxPixmap with DIcon::loadNxPixmap for better compatibility

chore: 修复编译警告

1. 在两个 main.cpp 文件中添加了翻译文件加载的错误处理
2. 移除了冗余的 Qt::AA_UseHighDpiPixmaps 属性设置
3. 使用 DIcon::loadNxPixmap 替代 DHiDPIHelper::loadNxPixmap 以获得更好的 兼容性