### PR TITLE
fix: update lastore config paths to new dde namespace

### DIFF
--- a/src/dde-abrecovery/recoverydialog.cpp
+++ b/src/dde-abrecovery/recoverydialog.cpp
@@ -263,18 +263,18 @@ void RecoveryWidget::initUI()
     reasonLabel->setContentsMargins(QMargins(10, 0, 10, 0));
     QString reasonMsg;
     DFontSizeManager::instance()->bind(reasonLabel, DFontSizeManager::T4, QFont::DemiBold);
-    const QString upgradeStatus = DConfigHelper::instance()->getConfig("org.deepin.lastore", "org.deepin.lastore", "","upgrade-status", 0).toString();
+    const QString upgradeStatus = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "","upgrade-status", 0).toString();
     QJsonParseError json_err;
     QJsonDocument upgradeStatusMessage = QJsonDocument::fromJson(upgradeStatus.toUtf8(), &json_err);
     if (json_err.error != QJsonParseError::NoError) {
-        qWarning() << "org.deepin.lastore upgrade-status, json parse error: " << json_err.errorString();
+        qWarning() << "org.deepin.dde.lastore upgrade-status, json parse error: " << json_err.errorString();
         reasonMsg = tr("Updates failed.");
     } else {
         const QJsonObject &object = upgradeStatusMessage.object();
         const QString status = object.value("Status").toString();
         const QString reasonCode = object.value("ReasonCode").toString();
 
-        qInfo() << "org.deepin.lastore, upgrade-status: " << status << ", reason code: " << reasonCode;
+        qInfo() << "org.deepin.dde.lastore, upgrade-status: " << status << ", reason code: " << reasonCode;
 
         // running, 代表在更新过程中被中断
         if (status == "running") {

--- a/src/dde-update/updateworker.cpp
+++ b/src/dde-update/updateworker.cpp
@@ -542,7 +542,7 @@ void UpdateWorker::checkStatusAfterSessionActive()
             return;
         }
     }
-    const int lastoreDaemonStatus = DConfigHelper::instance()->getConfig("org.deepin.lastore", "org.deepin.lastore", "","lastore-daemon-status", 0).toInt();
+    const int lastoreDaemonStatus = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "","lastore-daemon-status", 0).toInt();
     qInfo() << "Lastore daemon status: " << lastoreDaemonStatus;
     static const int IS_UPDATE_READY = 1; // 第一位表示更新是否可用
     const bool isUpdateReady = lastoreDaemonStatus & IS_UPDATE_READY;


### PR DESCRIPTION
1. Changed config paths from "org.deepin.lastore" to "org.deepin.dde.lastore" in both recoverydialog.cpp and updateworker.cpp
2. Updated corresponding log messages to reflect new namespace
3. This change aligns with the new DDE namespace convention for consistency across the project

fix: 更新lastore配置路径到新的dde命名空间

1. 在recoverydialog.cpp和updateworker.cpp中将配置路径 从"org.deepin.lastore"改为"org.deepin.dde.lastore"
2. 更新了相应的日志消息以反映新的命名空间
3. 此更改符合项目新的DDE命名空间约定，保持一致性

pms: BUG-313665