### PR TITLE
fix: change update mode types from int to quint64

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -166,12 +166,12 @@ bool UpdateDBusProxy::autoClean()
     return qvariant_cast<bool>(m_managerInter->property("AutoClean"));
 }
 
-uint UpdateDBusProxy::updateMode()
+quint64 UpdateDBusProxy::updateMode()
 {
-    return qvariant_cast<uint>(m_managerInter->property("UpdateMode"));
+    return qvariant_cast<quint64>(m_managerInter->property("UpdateMode"));
 }
 
-void UpdateDBusProxy::setUpdateMode(qulonglong value)
+void UpdateDBusProxy::setUpdateMode(quint64 value)
 {
     m_managerInter->setProperty("UpdateMode", QVariant::fromValue(value));
 }
@@ -191,12 +191,12 @@ QString UpdateDBusProxy::hardwareId()
     return qvariant_cast<QString>(m_managerInter->property("HardwareId"));
 }
 
-int UpdateDBusProxy::checkUpdateMode()
+quint64 UpdateDBusProxy::checkUpdateMode()
 {
-    return qvariant_cast<int>(m_managerInter->property("CheckUpdateMode"));
+    return qvariant_cast<quint64>(m_managerInter->property("CheckUpdateMode"));
 }
 
-void UpdateDBusProxy::setCheckUpdateMode(int value)
+void UpdateDBusProxy::setCheckUpdateMode(quint64 value)
 {
     m_managerInter->setProperty("CheckUpdateMode", QVariant::fromValue(value));
 }

--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -58,8 +58,8 @@ public:
     bool autoClean();
 
     Q_PROPERTY(qulonglong UpdateMode READ updateMode WRITE setUpdateMode NOTIFY UpdateModeChanged)
-    uint updateMode();
-    void setUpdateMode(qulonglong value);
+    quint64 updateMode();
+    void setUpdateMode(quint64 value);
 
     Q_PROPERTY(QList<QDBusObjectPath> JobList READ jobList NOTIFY JobListChanged)
     QList<QDBusObjectPath> jobList();
@@ -69,8 +69,8 @@ public:
 
     QString hardwareId();
 
-    int checkUpdateMode();
-    void setCheckUpdateMode(int value);
+    quint64 checkUpdateMode();
+    void setCheckUpdateMode(quint64 value);
 
     QString idleDownloadConfig();
     QString downloadSpeedLimitConfig();

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -136,9 +136,9 @@ public:
     QString lastCheckUpdateTime() const { return m_lastCheckUpdateTime; }
     void setLastCheckUpdateTime(const QString &lastTime);
 
-    int checkUpdateMode() const { return m_checkUpdateMode; }
-    void setCheckUpdateMode(int value);
-
+    quint64 checkUpdateMode() const { return m_checkUpdateMode; }
+    void setCheckUpdateMode(quint64 value);
+    void refreshUpdateItemsChecked();
 
     // ---------------下载、备份、安装列表数据---------------
     UpdateListModel *preUpdatelistModel() const { return m_preUpdatelistModel; }
@@ -326,7 +326,7 @@ Q_SIGNALS:
     void checkUpdateErrTipsChanged();
     void checkBtnTextChanged();
     void lastCheckUpdateTimeChanged();
-    void checkUpdateModeChanged(int);
+    void checkUpdateModeChanged(quint64);
 
     // 下载、备份、安装列表数据
     void preUpdatelistModelChanged();
@@ -396,7 +396,7 @@ private:
     QString m_checkUpdateErrTips;
     QString m_checkBtnText;
     QString m_lastCheckUpdateTime;
-    int m_checkUpdateMode;
+    quint64 m_checkUpdateMode;
 
     // 下载、备份、安装列表数据
     UpdateListModel *m_preUpdatelistModel; // preUpdateList qml data

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -500,6 +500,7 @@ void UpdateWorker::setUpdateInfo()
             isUpdated = false;
         }
     }
+    m_model->refreshUpdateItemsChecked();
     m_model->refreshUpdateStatus();
     m_model->updateAvailableState();
     m_model->setLastStatus(isUpdated ? Updated : UpdatesAvailable, __LINE__);
@@ -1264,8 +1265,8 @@ void UpdateWorker::onRequestRetry(int type, int updateTypes)
 
 void UpdateWorker::setCheckUpdateMode(int type, bool isChecked)
 {
-    const int currentMode = m_model->checkUpdateMode();
-    const int outMode = isChecked ? (currentMode | type) : (currentMode & ~type);
+    quint64 currentMode = m_model->checkUpdateMode();
+    quint64 outMode = isChecked ? (currentMode | type) : (currentMode & ~type);
 
     m_updateInter->setCheckUpdateMode(outMode);
 }


### PR DESCRIPTION
1. Changed update mode related types from int/uint to quint64 for consistency with D-Bus interface
2. Added refreshUpdateItemsChecked() method to properly update item checked states when mode changes
3. Fixed debounce timer to use quint64 for CheckUpdateMode property changes
4. Updated all related method signatures and property types to match

These changes were necessary because:
1. The D-Bus interface uses 64-bit unsigned integers for update modes
2. Using smaller types could cause data truncation and incorrect behavior
3. The refresh logic needed to be separated from status refresh for better maintainability
4. Ensures type safety across the entire update mode handling chain

fix: 将更新模式类型从 int 改为 quint64

1. 将更新模式相关类型从 int/uint 改为 quint64 以保持与 D-Bus 接口一致
2. 添加 refreshUpdateItemsChecked() 方法以便在模式变更时正确更新项目选中 状态
3. 修复防抖定时器使用 quint64 处理 CheckUpdateMode 属性变更
4. 更新所有相关方法签名和属性类型以匹配

这些变更是必要的因为：
1. D-Bus 接口使用 64 位无符号整数表示更新模式
2. 使用较小类型可能导致数据截断和错误行为
3. 需要将刷新逻辑与状态刷新分离以提高可维护性
4. 确保整个更新模式处理链的类型安全

pms: Bug-313905