### PR TITLE
fix: correct BusyIndicator running state in UpdateControl

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -93,7 +93,7 @@ ColumnLayout {
 
         BusyIndicator {
             id: initAnimation
-            running: true
+            running: initAnimation.visible
             visible: busyState
             implicitWidth: 32
             implicitHeight: 32


### PR DESCRIPTION
The BusyIndicator's running property was changed from always true to be dependent on its visibility. This ensures the animation only runs when the indicator is actually visible, improving performance by preventing unnecessary animations when hidden. The change maintains the same visual behavior while being more efficient.

fix: 修正UpdateControl中BusyIndicator的运行状态

BusyIndicator的running属性从始终为true改为依赖于其可见性。这确保动画仅在
指示器实际可见时运行，通过防止在隐藏时不必要的动画来提高性能。该变更保持
了相同的视觉行为，同时更加高效。

Log: