### PR TITLE
fix: enhance update list display and version info

### DIFF
--- a/src/dcc-update-plugin/operation/updatelistmodel.cpp
+++ b/src/dcc-update-plugin/operation/updatelistmodel.cpp
@@ -25,6 +25,8 @@ QVariant UpdateListModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case Title:
         return data->name();
+    case Version:
+        return data->currentVersion();
     case TitleDescription:
         return data->explain();
     case UpdateLog:

--- a/src/dcc-update-plugin/operation/updatelistmodel.h
+++ b/src/dcc-update-plugin/operation/updatelistmodel.h
@@ -19,6 +19,7 @@ class UpdateListModel : public QAbstractListModel
 public:
     enum updateRoles {
         Title = Qt::UserRole + 1,
+        Version,
         TitleDescription,
         UpdateLog,
         ReleaseTime,
@@ -48,6 +49,7 @@ public:
     {
         QHash<int, QByteArray> roles;
         roles[Title] = "title";
+        roles[Version] = "version";
         roles[TitleDescription] = "titleDescription";
         roles[UpdateLog] = "updateLog";
         roles[ReleaseTime] = "releaseTime";

--- a/src/dcc-update-plugin/operation/updateloghelper.h
+++ b/src/dcc-update-plugin/operation/updateloghelper.h
@@ -68,8 +68,8 @@ struct SystemUpdateLog {
     QString showVersion;
     QString cnLog = "";
     QString enLog = "";
+    QString systemVersion;
     QString publishTime;
-    QString upgradeTime; // 更新时间
     int isUnstable=0;
     int logType = 1;
 
@@ -81,8 +81,9 @@ struct SystemUpdateLog {
         item.showVersion = obj.value("showVersion").toString();
         item.cnLog = obj.value("cnLog").toString();
         item.enLog = obj.value("enLog").toString();
-        item.isUnstable = obj.value("isUnstable").toInt();
+        item.systemVersion = obj.value("systemVersion").toString();
         item.publishTime = DCC_NAMESPACE::utcDateTime2LocalDate(obj.value("publishTime").toString());
+        item.isUnstable = obj.value("isUnstable").toInt();
         if (obj.contains("logType")) {
             item.logType = obj.value("logType").toInt();
         }

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -240,6 +240,10 @@ void UpdateWorker::activate()
                 if (!watcher->isError()) {
                     QDBusPendingReply<QString> reply = watcher->reply();
                     UpdateLogHelper::ref().handleUpdateLog(reply.value());
+                    auto resultMap = m_model->getAllUpdateInfos();
+                    for (UpdateType type : resultMap.keys()) {
+                        UpdateLogHelper::ref().updateItemInfo(resultMap.value(type));
+                    }
                 } else {
                     qCWarning(DCC_UPDATE_WORKER) << "Get update log failed";
                 }
@@ -1399,6 +1403,10 @@ void UpdateWorker::onCheckUpdateStatusChanged(const QString& value)
             if (!watcher->isError()) {
                 QDBusPendingReply<QString> reply = watcher->reply();
                 UpdateLogHelper::ref().handleUpdateLog(reply.value());
+                auto resultMap = m_model->getAllUpdateInfos();
+                for (UpdateType type : resultMap.keys()) {
+                    UpdateLogHelper::ref().updateItemInfo(resultMap.value(type));
+                }
             } else {
                 qCWarning(DCC_UPDATE_WORKER) << "Get update log failed";
             }

--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -55,8 +55,9 @@ ColumnLayout {
                     font {
                         pixelSize: D.DTK.fontManager.t5.pixelSize
                         family: D.DTK.fontManager.t5.family
-                        bold: true
+                        weight: Font.Medium
                     }
+                    color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                     text: updateTitle
                 }
             }

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -14,7 +14,6 @@ Rectangle {
     id: root
 
     property alias model: repeater.model
-    signal clicked(int index, bool checked)
 
     color: "transparent"
     implicitHeight: layoutView.height
@@ -53,13 +52,14 @@ Rectangle {
 
                     ColumnLayout {
                         Layout.alignment: Qt.AlignRight
-                        spacing: 10
+                        spacing: 6
 
                         RowLayout {
                             Label {
                                 Layout.alignment: Qt.AlignLeft
                                 text: model.title
-                                font.pixelSize: 14
+                                font: D.DTK.fontManager.t6
+                                color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                                 width: 100
                                 Layout.fillWidth: true
                             }
@@ -80,26 +80,22 @@ Rectangle {
                             Layout.alignment: Qt.AlignLeft
                             horizontalAlignment: Text.AlignLeft
                             Layout.fillWidth: true
-                            font.pixelSize: 12
-                            text: model.titleDescription
-                            wrapMode: Text.WordWrap
-                        }
-
-                        Rectangle {
-                            visible: false
-                            height: 1
-                            color: parent.palette.window
-                            Layout.topMargin: 10
-                            Layout.bottomMargin: 10
-                            Layout.fillWidth: true
+                            font: D.DTK.fontManager.t8
+                            color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                            visible: model.version.length !== 0
+                            text: qsTr("Version:") + model.version
                         }
 
                         D.Label {
-                            visible: false
                             Layout.alignment: Qt.AlignLeft
                             horizontalAlignment: Text.AlignLeft
-                            font.pixelSize: 12
-                            text: qsTr("Updates:")
+                            Layout.fillWidth: true
+                            font: D.DTK.fontManager.t8
+                            text: model.titleDescription
+                            wrapMode: Text.WordWrap
+                            onLinkActivated: (link)=> {
+                                dccData.work().openUrl(link)
+                            }  
                         }
 
                         D.Label {
@@ -107,9 +103,8 @@ Rectangle {
                             Layout.alignment: Qt.AlignLeft
                             horizontalAlignment: Text.AlignLeft
                             text: model.updateLog
-                            font.pixelSize: 12
+                            font: D.DTK.fontManager.t8
                             Layout.fillWidth: true
-                            opacity: 0.7
                             wrapMode: Text.WordWrap
                             visible: false
                         }
@@ -120,33 +115,19 @@ Rectangle {
                             Layout.alignment: Qt.AlignLeft
                             horizontalAlignment: Text.AlignLeft
                             text: ""
-                            font.pixelSize: 12
+                            font: D.DTK.fontManager.t8
                             Layout.fillWidth: true
-                            opacity: 0.7
                             wrapMode: Text.WordWrap
                         }
 
                         RowLayout {
-                            RowLayout {
-                                visible: releaseContent.text.length !== 0
+                            D.Label {
+                                id: releaseTitle
                                 Layout.alignment: Qt.AlignLeft
-                                D.Label {
-                                    id: releaseTitle
-                                    Layout.alignment: Qt.AlignLeft
-                                    horizontalAlignment: Text.AlignLeft
-                                    font.pixelSize: 12
-                                    text: qsTr("Release time:")
-                                    opacity: 0.7
-                                }
-
-                                D.Label {
-                                    id: releaseContent
-                                    Layout.alignment: Qt.AlignLeft
-                                    horizontalAlignment: Text.AlignLeft
-                                    font.pixelSize: 12
-                                    text: model.releaseTime
-                                    opacity: 0.7
-                                }
+                                horizontalAlignment: Text.AlignLeft
+                                visible: model.releaseTime.length !== 0
+                                font: D.DTK.fontManager.t8
+                                text: qsTr("Release time:") + model.releaseTime
                             }
 
                             Item {
@@ -170,14 +151,8 @@ Rectangle {
 
                 background: DccItemBackground {
                     separatorVisible: true
-                    //highlightEnable: false
-                }
-
-                onClicked: {
-                    root.clicked(index, !model.checked)
                 }
             }
         }
     }
 }
-

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>قم بطي ذلك</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Replega</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>Einfahren</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -250,19 +256,19 @@
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Einfahren</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Contraer</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>Puske</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Tiivistetty</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>Colapsar</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>折りたたむ</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>Жыртық</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>कुप्लेस</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Inklappen</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Zwiń</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>Recolher</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Palose</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,7 +398,7 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>Daralt</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>Згорнути</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -79,6 +79,10 @@
         <source>Collapse</source>
         <translation>Thu gọn</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -76,6 +78,10 @@
     <message>
         <source>Collapse</source>
         <translation>收起</translation>
+    </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +160,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -250,19 +256,19 @@
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -434,7 +440,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -77,20 +79,24 @@
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
+    <message>
+        <source>Version:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export logs and save them automatically to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +160,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -250,19 +256,19 @@
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -434,7 +440,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>


### PR DESCRIPTION
1. Added version field to UpdateListModel for displaying package versions
2. Modified SystemUpdateLog structure to include systemVersion and remove unused upgradeTime
3. Updated UpdateWorker to sync update info with log helper
4. Improved QML layout with better typography and version display
5. Removed unused click signal and simplified release time display
6. Added proper font sizing using DTK font manager

fix: 增强更新列表显示和版本信息

1. 在 UpdateListModel 中添加版本字段用于显示软件包版本
2. 修改 SystemUpdateLog 结构体，添加 systemVersion 并移除未使用的 upgradeTime
3. 更新 UpdateWorker 以同步更新信息与日志助手
4. 改进 QML 布局，优化排版并添加版本显示
5. 移除未使用的点击信号并简化发布时间显示
6. 使用 DTK 字体管理器添加适当的字体大小设置

pms: Bug-318147