### PR TITLE
feat: Prohibit checking for updates when automatic restore is enabled

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -186,6 +186,11 @@ QString UpdateDBusProxy::updateStatus()
     return qvariant_cast<QString>(m_managerInter->property("UpdateStatus"));
 }
 
+bool UpdateDBusProxy::immutableAutoRecovery()
+{
+    return qvariant_cast<bool>(m_managerInter->property("ImmutableAutoRecovery"));
+}
+
 QString UpdateDBusProxy::hardwareId()
 {
     return qvariant_cast<QString>(m_managerInter->property("HardwareId"));

--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -67,6 +67,9 @@ public:
     Q_PROPERTY(QString updateStatus  READ updateStatus NOTIFY UpdateStatusChanged)
     QString updateStatus();
 
+    Q_PROPERTY(bool ImmutableAutoRecovery READ immutableAutoRecovery NOTIFY ImmutableAutoRecoveryChanged)
+    bool immutableAutoRecovery();
+
     QString hardwareId();
 
     quint64 checkUpdateMode();
@@ -142,6 +145,7 @@ signals:
     void AutoCleanChanged(bool value) const;
     void UpdateModeChanged(qulonglong value) const;
     void UpdateStatusChanged(QString value) const;
+    void ImmutableAutoRecoveryChanged(bool value) const;
     void managerInterServiceValidChanged(bool value) const;
 
     // Power

--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -139,7 +139,11 @@ void UpdateModel::refreshIsUpdateDisabled()
         setIsUpdateDisabled(true);
         setUpdateDisabledIcon("update_no_active");
         setUpdateDisabledTips(tr("Your system is not activated, and it failed to connect to update services"));
-    }else if (m_updateProhibited) {
+    } else if (m_immutableAutoRecovery) {
+        setIsUpdateDisabled(true);
+        setUpdateDisabledIcon("update_prohibit");
+        setUpdateDisabledTips(tr("The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator"));
+    } else if (m_updateProhibited) {
         setIsUpdateDisabled(true);
         setUpdateDisabledIcon("update_prohibit");
         setUpdateDisabledTips(tr("The system updates are disabled. Please contact your administrator for help"));
@@ -202,6 +206,17 @@ void UpdateModel::setLastStatus(const UpdatesStatus& status, int line, int types
         m_lastStatus = status;
         Q_EMIT lastStatusChanged(m_lastStatus);
     }
+}
+
+void UpdateModel::setImmutableAutoRecovery(bool value)
+{
+    qCInfo(DCC_UPDATE_MODEL) << "Set immutable auto recovery: " << value;
+    if (m_immutableAutoRecovery == value)
+        return;
+
+    m_immutableAutoRecovery = value;
+    Q_EMIT immutableAutoRecoveryChanged(value);
+    refreshIsUpdateDisabled();
 }
 
 void UpdateModel::setShowCheckUpdate(bool value)

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -115,6 +115,9 @@ public:
     int lastStatus() const { return m_lastStatus; }
     void setLastStatus(const UpdatesStatus &status, int line, int types = 0);
 
+    bool immutableAutoRecovery() const { return m_immutableAutoRecovery; }
+    void setImmutableAutoRecovery(bool value);
+
     // ---------------检查更新页面数据---------------
     bool showCheckUpdate() const { return m_showCheckUpdate; }
     void setShowCheckUpdate(bool value);
@@ -326,6 +329,7 @@ Q_SIGNALS:
 
     void batterIsOKChanged(bool isOK);
     void lastStatusChanged(int status);
+    void immutableAutoRecoveryChanged(bool value);
 
     // 检查更新页面数据
     void showCheckUpdateChanged();
@@ -398,6 +402,7 @@ private:
     QString m_updateDisabledTips;
     bool m_batterIsOK;
     int m_lastStatus;
+    bool m_immutableAutoRecovery;
 
     // 检查更新页面数据
     bool m_showCheckUpdate;

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -158,6 +158,7 @@ void UpdateWorker::initConnect()
     connect(m_updateInter, &UpdateDBusProxy::JobListChanged, this, &UpdateWorker::onJobListChanged);
     connect(m_updateInter, &UpdateDBusProxy::UpdateStatusChanged, this, &UpdateWorker::onUpdateStatusChanged);
     connect(m_updateInter, &UpdateDBusProxy::ClassifiedUpdatablePackagesChanged, this, &UpdateWorker::onClassifiedUpdatablePackagesChanged);
+    connect(m_updateInter, &UpdateDBusProxy::ImmutableAutoRecoveryChanged, m_model, &UpdateModel::setImmutableAutoRecovery);
 
     QDBusConnection::systemBus().connect("org.deepin.dde.Lastore1",
                                          "/org/deepin/dde/Lastore1",
@@ -218,6 +219,7 @@ void UpdateWorker::activate()
     m_model->setUpdateNotify(m_updateInter->updateNotify());
     m_model->setAutoCleanCache(m_updateInter->autoClean());
     m_model->setP2PUpdateEnabled(m_updateInter->p2pUpdateEnable());
+    m_model->setImmutableAutoRecovery(m_updateInter->immutableAutoRecovery());
     if (IsCommunitySystem) {
         m_model->setSmartMirrorSwitch(m_updateInter->enable());
     }

--- a/src/dcc-update-plugin/qml/UpdateDisable.qml
+++ b/src/dcc-update-plugin/qml/UpdateDisable.qml
@@ -18,21 +18,30 @@ ColumnLayout {
         clip: true
 
         ColumnLayout {
-            anchors.centerIn: parent
+            anchors.fill: parent
             spacing: 0
 
+            Item {
+                Layout.fillHeight: true
+            }
+
             Image {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                Layout.alignment: Qt.AlignHCenter
                 source: dccData.model().updateDisabledIcon
                 height: 140
             }
 
             D.Label {
-                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                width: implicitWidth
-                height: 30
+                Layout.fillWidth: true
                 text: dccData.model().updateDisabledTips
                 font.pixelSize: 12
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                wrapMode: Text.WordWrap
+            }
+
+            Item {
+                Layout.fillHeight: true
             }
         }
     }

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Les actualitzacions del sistema estan desactivades. Poseu-vos en contacte amb l&apos;administrador per obtenir ajuda.</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -245,24 +247,28 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Die System-Aktualisierungen sind ausgeschaltet. Bitte kontaktieren Sie Ihren Administrator.</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Einfahren</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Las actualizaciones del sistema están desactivadas. Póngase en contacto con su administrador para obtener ayuda.</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -75,7 +77,7 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -86,11 +88,11 @@
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Päivitykset ovat poistettu käytöstä. Pyydä apua järjestelmänvalvojaltasi.</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -245,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>システムアップデートが無効化されています。詳細はシステム管理者にお問い合わせください</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Systeemupdates zijn uitgeschakeld. Neem contact op met je systeembeheerder.</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Aktualizacje systemu są wyłączone. Skontaktuj się z administratorem, aby uzyskać pomoc</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -245,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>As atualizações do sistema estão desabilitadas. Entre em contato com o administrador para obter ajuda.</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -75,7 +77,7 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -86,11 +88,11 @@
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -245,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Përditësimet e sistemit janë të çaktivizuara. Ju lutemi, për ndihmë, lidhuni me përgjegjësin tuaj</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
@@ -392,7 +398,7 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -75,7 +77,7 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -86,11 +88,11 @@
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Sistem güncellemeleri devre dışı bırakıldı. Lütfen yardım için yöneticinizle iletişime geçin</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>Оновлення системи вимкнено. Будь ласка, зв&apos;яжіться із адміністратором для довідки.</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -247,6 +247,10 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -244,6 +246,10 @@
     <message>
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>系统已被禁止更新，请联系管理员！</translation>
+    </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -245,24 +247,28 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>系統已被禁止更新，請聯繫管理員！</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
@@ -438,7 +444,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -245,24 +247,28 @@
         <source>The system updates are disabled. Please contact your administrator for help</source>
         <translation>系統已被禁止更新，請聯絡管理員！</translation>
     </message>
+    <message>
+        <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -365,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -392,15 +398,15 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
@@ -438,7 +444,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>


### PR DESCRIPTION
After enabling automatic restore, updates are invalid, so checking for updates is directly prohibited

pms: TASK-378055