### PR TITLE
fix: adjust UI layout and translation settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories(
 
 set(TRANSLATION_LANGUAGES
     af ak am_ET ar ar_EG ast az bg bn bo br ca cgg cs da de de_CH el en en_AU
-    en_GB en_US eo es es_MX et eu fa fi fil fr gl_ES he hi_IN hr hu hy id it
+    en_GB en_US eo es et eu fa fi fil fr gl_ES he hi_IN hr hu hy id it
     ja kab ka kk km_KH kn_IN ko ku ku_IQ ky ky@Arab la lo lt lv ml mn mr ms
     nb ne nl pa pam pl ps pt pt_BR ro ru sc si sk sl sq sr sv sw ta te th tr
     tzm ug uk ur uz vi zh_CN zh_HK zh_TW

--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -141,7 +141,7 @@ ColumnLayout {
                     to: 1
                     value: processValue
                     implicitHeight: 8
-                    implicitWidth: 240
+                    implicitWidth: 210
                 }
 
                 D.ActionButton {

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -31,8 +31,8 @@ Rectangle {
             delegate: D.ItemDelegate {
                 id: itemCtl
                 Layout.fillWidth: true
-                leftPadding: 10
-                rightPadding: 10
+                leftPadding: 6
+                rightPadding: 12
                 topPadding: 10
                 cascadeSelected: true
                 contentFlow: true


### PR DESCRIPTION
1. Removed es_MX from translation languages list as it's redundant (es covers Mexican Spanish)
2. Reduced progress bar width from 240 to 210 in UpdateControl.qml for better visual balance
3. Adjusted left/right padding in UpdateList.qml (10->6 left, 10->12 right) to improve item spacing
4. These changes improve UI consistency and remove unnecessary translation redundancy

fix: 调整UI布局和翻译设置

1. 从翻译语言列表中移除es_MX（西班牙语已包含墨西哥西班牙语）
2. 将UpdateControl.qml中的进度条宽度从240减少到210以获得更好的视觉平衡
3. 调整UpdateList.qml中的左右边距（左10->6，右10->12）以改善项目间距
4. 这些更改提高了UI一致性并移除了不必要的翻译冗余

pms: Bug-321647