### PR TITLE
fix: update control and list visibility improvements

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -21,6 +21,7 @@ ColumnLayout {
     property bool processState: false
     property bool busyState: false
     property bool updateListEnable: true
+    property bool updateListcheck: true
     property bool isDownloading: false
     property bool isPauseOrNot: false
     property bool showLogButton: false
@@ -123,8 +124,8 @@ ColumnLayout {
             id: initAnimation
             running: initAnimation.visible
             visible: busyState
-            implicitWidth: 32
-            implicitHeight: 32
+            implicitWidth: 24
+            implicitHeight: 24
         }
 
         ColumnLayout {
@@ -199,5 +200,6 @@ ColumnLayout {
     UpdateList {
         id: updatelistModel
         enabled: updateListEnable
+        checkIconVisible: updateListcheck
     }
 }

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -14,6 +14,7 @@ Rectangle {
     id: root
 
     property alias model: repeater.model
+    property bool checkIconVisible: true
 
     color: "transparent"
     implicitHeight: layoutView.height
@@ -68,6 +69,7 @@ Rectangle {
                                 Layout.alignment: Qt.AlignRight
                                 checked: model.checked
                                 size: 18
+                                visible: checkIconVisible
 
                                 onClicked: {
                                     repeater.model.setChecked(index, !model.checked)

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -178,6 +178,7 @@ DccObject {
             updateTitle: qsTr("Update installation successful")
             updateTips: qsTr("To ensure proper functioning of your system and applications, please restart your computer after the update")
             btnActions: [ qsTr("Reboot now") ]
+            updateListcheck: false
 
             onBtnClicked: function(index, updateType) {
                 dccData.work().reStart()
@@ -340,7 +341,7 @@ DccObject {
 
         page: UpdateControl {
             updateListModels: dccData.model().preUpdatelistModel
-            updateTitle: qsTr("Updates Available")
+            updateTitle: !dccData.model().downloadWaiting ? qsTr("Updates Available") : qsTr("Downloading updates...")
             btnActions: [ qsTr("Download") ]
             updateTips: qsTr("Update size: ") + dccData.model().preUpdatelistModel.downloadSize
             busyState: dccData.model().downloadWaiting


### PR DESCRIPTION
1. Added updateListcheck property to control check icon visibility in UpdateControl
2. Reduced initAnimation dimensions from 32x32 to 24x24 for better UI proportion
3. Modified update title to show "Downloading updates..." during download state
4. Disabled check icons in success dialog by setting updateListcheck to false
5. Connected checkIconVisible property between UpdateControl and UpdateList components

fix: 更新控制和列表可见性改进

1. 添加updateListcheck属性控制UpdateControl中的勾选图标可见性
2. 将initAnimation尺寸从32x32减小到24x24以获得更好的UI比例
3. 修改更新标题在下载状态时显示"正在下载更新..."
4. 通过设置updateListcheck为false在成功对话框中禁用勾选图标
5. 在UpdateControl和UpdateList组件之间连接checkIconVisible属性

pms: bug-321597