### PR TITLE
refactor: optimize build system security flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_FLAGS "-g -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 set(QT_VERSION_MAJOR 6)
-
-# 增加安全编译参数
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -fPIC")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -fPIC")
-set(CMAKE_EXE_LINKER_FLAGS  "-z relro -z now -z noexecstack -pie")
-add_compile_options(-fPIC)
 
 if (DEFINED ENABLE_MIEEE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,11 @@
 include /usr/share/dpkg/default.mk
 SYSTYPE=Desktop
 SYSTYPE=$(shell cat /etc/deepin-version | grep Type= | awk -F'=' '{print $$2}')
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 %:
 	dh $@ --parallel
 

--- a/src/dcc-update-plugin/CMakeLists.txt
+++ b/src/dcc-update-plugin/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_FLAGS "-g -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 
 # Find the library
 find_package(PkgConfig REQUIRED)

--- a/src/dde-abrecovery/CMakeLists.txt
+++ b/src/dde-abrecovery/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_FLAGS "-g -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 
 
 # Find the library


### PR DESCRIPTION
1. Removed redundant security flags from CMakeLists.txt since they are now handled by debian/rules
2. Added comprehensive security hardening flags in debian/rules using DEB_BUILD_MAINT_OPTIONS
3. Standardized compiler flag handling across all CMakeLists.txt files by using ${CMAKE_CXX_FLAGS} consistently
4. Kept -g flag for debugging but moved it to be appended to existing flags

The changes centralize security flag management in the Debian build system rather than having them scattered across multiple CMake files. This makes the build configuration more maintainable and consistent with Debian packaging standards.

refactor: 优化构建系统安全标志

1. 从 CMakeLists.txt 中移除冗余的安全标志，现在由 debian/rules 统一处理
2. 在 debian/rules 中使用 DEB_BUILD_MAINT_OPTIONS 添加全面的安全加固标志
3. 通过统一使用 ${CMAKE_CXX_FLAGS} 标准化所有 CMakeLists.txt 文件中的编 译器标志处理
4. 保留 -g 调试标志但改为追加到现有标志中

这些变更将安全标志管理集中到 Debian 构建系统中，而不是分散在多个 CMake
文件中，使构建配置更易维护且符合 Debian 打包标准。