### PR TITLE
feat: add battery check before system updates

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -666,6 +666,13 @@ void UpdateWorker::setDownloadJob(const QString& jobPath)
 
 void UpdateWorker::doUpgrade(int updateTypes, bool doBackup)
 {
+    if (!m_model->batterIsOK()) {
+        notifyInfo(tr("Update"), tr("Please plug in and then install updates."));
+        return;
+    }
+
+    emit startDoUpgrade();
+
     qCInfo(DCC_UPDATE_WORKER) << "Do upgrade, update types:" << updateTypes << ", whether do backup:" << doBackup;
     cleanLaStoreJob(m_distUpgradeJob);
     cleanLaStoreJob(m_backupJob);
@@ -700,6 +707,11 @@ void UpdateWorker::reStart()
 
 void UpdateWorker::modalUpgrade(bool rebootAfterUpgrade)
 {
+    if (!m_model->batterIsOK()) {
+        notifyInfo(tr("Update"), tr("Please plug in and then install updates."));
+        return;
+    }
+
     qCInfo(DCC_UPDATE_WORKER) << "request modal upgrade, reboot after upgrade:" << rebootAfterUpgrade;
     if (rebootAfterUpgrade) {
         m_updateInter->UpdateAndReboot();

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -125,6 +125,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void systemActivationChanged(bool systemActivation);
     void requestCloseTestingChannel();
+    void startDoUpgrade();
 
 private:
     Dtk::Core::DConfig *m_lastoreDConfig;

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -293,13 +293,19 @@ DccObject {
                 visible: false
                 onSilentBtnClicked: {
                     dccData.work().doUpgrade(updateType, true)
-                    close()
                 }
                 onUpgradeRebootBtnClicked: {
                     dccData.work().modalUpgrade(true)
                 }
                 onUpgradeShutdownBtnClicked: {
                     dccData.work().modalUpgrade(false)
+                }
+            }
+
+            Connections {
+                target: dccData.work()
+                function onStartDoUpgrade() {
+                    updateSelectDialog.close()
                 }
             }
         }

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Actualitza</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -247,26 +249,26 @@
     </message>
     <message>
         <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -369,11 +371,11 @@
     </message>
     <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Einfahren</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -400,15 +402,19 @@
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
         <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Actualizar</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Päivitä</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -413,6 +413,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>アップデート</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Bijwerken</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Aktualizuj</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Atualizar</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -396,7 +398,7 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Përditësim</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -90,7 +92,7 @@
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -247,7 +249,7 @@
     </message>
     <message>
         <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Güncelle</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>Оновлення</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -412,6 +412,10 @@
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -409,6 +411,10 @@
     <message>
         <source>Update</source>
         <translation>更新</translation>
+    </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -410,6 +412,10 @@
         <source>Update</source>
         <translation>更新</translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>
@@ -442,7 +448,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -410,6 +412,10 @@
         <source>Update</source>
         <translation>更新</translation>
     </message>
+    <message>
+        <source>Please plug in and then install updates.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>update</name>
@@ -442,7 +448,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>


### PR DESCRIPTION
1. Added battery status check in UpdateWorker before starting upgrades
2. Show notification if battery is not plugged in
3. Added new signal startDoUpgrade to properly handle dialog closing
4. Updated translations for new battery check message
5. Modified update dialog to close only after upgrade starts

This change prevents system updates when running on battery to avoid potential issues from power loss during update process. The dialog now closes at the right time after the upgrade begins rather than immediately when clicking the button.

feat: 在系统更新前添加电池检查

1. 在UpdateWorker中添加升级前的电池状态检查
2. 如果未插入电源则显示通知
3. 添加新的startDoUpgrade信号以正确处理对话框关闭
4. 更新电池检查消息的翻译
5. 修改更新对话框只在升级开始后关闭

此更改可防止在电池供电时进行系统更新，以避免更新过程中断电可能导致的问
题。对话框现在会在升级开始后而不是点击按钮时立即关闭。

pms: Bug-320697