### PR TITLE
feat: improve keyboard navigation in update dialog

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSelectDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateSelectDialog.qml
@@ -63,6 +63,7 @@ D.DialogWindow {
                     normalDark: normal
                 }
                 Layout.fillWidth: true
+                focus: root.visible
                 onClicked: {
                     root.upgradeShutdownBtnClicked()
                 }


### PR DESCRIPTION
1. Added keyboard navigation between buttons using KeyNavigation properties
2. Implemented auto-focus on shutdownBtn when dialog becomes visible
3. Added unique ids to all buttons for better reference
4. Ensured circular navigation between all three buttons (silent, reboot, shutdown)

These changes improve accessibility by allowing keyboard-only users to navigate between options more efficiently. The auto-focus on the shutdown button provides a sensible default starting point for keyboard users.

feat: 改进更新对话框的键盘导航功能

1. 使用 KeyNavigation 属性添加按钮间的键盘导航
2. 实现对话框显示时自动聚焦到 shutdownBtn
3. 为所有按钮添加唯一ID以便引用
4. 确保三个按钮(静默安装、重启更新、关机更新)之间可循环导航

这些改进提升了可访问性，使仅使用键盘的用户能更高效地在选项间导航。自动聚
焦到关机按钮为键盘用户提供了合理的默认起始点。

pms: BUG-319237