### PR TITLE
fix: use DStandardPaths for home directory lookup

### DIFF
--- a/src/dde-update/updateworker.cpp
+++ b/src/dde-update/updateworker.cpp
@@ -26,6 +26,7 @@
 #include <QStandardPaths>
 
 #include <DDBusSender>
+#include <DStandardPaths>
 
 Q_LOGGING_CATEGORY(DDE_UPDATE_WORKER, "dde-update-worker")
 
@@ -662,8 +663,7 @@ bool UpdateWorker::exportUpdateLog()
         return false;
     }
 
-    QString homeDir = QString("/home/%1").arg(name);
-    QString desktopPath = QDir(homeDir).absoluteFilePath("Desktop");
+    QString desktopPath = Dtk::Core::DStandardPaths::homePath(uid) + "/Desktop";
 
     if (desktopPath.isEmpty()) {
         qWarning() << "Cannot get desktop path";


### PR DESCRIPTION
1. Replaced hardcoded home directory path construction with DStandardPaths utility
2. Changed from using username to UID for more reliable path resolution
3. Improves cross-platform compatibility and follows DTK conventions
4. Fixes potential issues with non-standard home directory locations

fix: 使用 DStandardPaths 查找主目录路径

1. 用 DStandardPaths 工具替换硬编码的主目录路径构造
2. 从使用用户名改为使用 UID 进行更可靠的路径解析
3. 提高跨平台兼容性并遵循 DTK 规范
4. 修复非标准主目录位置可能导致的潜在问题