### PR TITLE
fix: update testing channel description text

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -428,7 +428,7 @@ DccObject {
         name: "testingChannel"
         parentName: "updateSettingsPage"
         displayName: qsTr("Join Internal Testing Channel")
-        description: qsTr("Forum users at level 2 and above can join the beta test to receive the latest updates.")
+        description: qsTr("Join the internal testing channel to get deepin latest updates.")
         backgroundType: DccObject.Normal
         visible: advancedSetting.showDetails && dccData.model().isCommunitySystem()
         weight: 80

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">قم بطي ذلك</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Expandeix</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Els usuaris del fòrum de nivell 2 o superior poden unir-se a la prova beta per rebre les últimes actualitzacions.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Replega</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Només es permeten números entre 1 i 99999.</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -25,7 +27,7 @@
     <name>UpdateControl</name>
     <message>
         <source>View Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -75,22 +77,22 @@
     </message>
     <message>
         <source>Version:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateLogDialog</name>
     <message>
         <source>Update Log</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Close</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -247,26 +249,26 @@
     </message>
     <message>
         <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UpdateSelectDialog</name>
     <message>
         <source>The updates have been already downloaded. What do you want to do?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Silent Installation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Reboot</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update and Shut Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -364,16 +366,16 @@
         <translation>Aufklappen</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Forumsteilnehmer auf Stufe 2 und höher können dem Betatest beitreten um die neuesten Aktualisierungen zu erhalten.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Einfahren</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -400,11 +402,11 @@
     </message>
     <message>
         <source>Log export failed, please try again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The log has been exported to the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Expandir</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Los usuarios del foro de nivel 2 o superior pueden unirse a la prueba beta para recibir las últimas actualizaciones.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Contraer</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Sólo se admiten números entre 1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">Puske</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Laajenna</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Foorumin käyttäjät tasolla 2 ja sitä korkeammalla voivat liittyä beta-testiin viimeisillä päivityksillä.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Tiivistetty</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Numerot väliltä 1-99999 ovat sallittuja</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Développer</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Les utilisateurs du forum de niveau 2 et supérieur peuvent participer au test bêta pour recevoir les dernières mises à jour.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Réduire</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Seuls les nombres compris entre 1-99999 sont autorisés.</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -367,15 +367,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">Colapsar</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>展開</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Level 2以上のフォーラムユーザーがベータテストに参加し最新のアップデートを受け取ることができます。</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>折りたたむ</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>1から99999の間で入力してください</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">Жыртық</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_lo.ts
+++ b/src/dcc-update-plugin/translations/update_lo.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="lo">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="lo">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>ພອງຕົວ</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>ຜູ້ໃຊ້ເວທີປຶກສາຫາລືໃນລະດັບ 2 ແລະຂ້າງເທິງສາມາດເຂົ້າຮ່ວມທົດລອງເບຕ້າເພື່ອຮັບການອັບເດດຫຼ້າສຸດ.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>ຫຍໍ້</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>ມີພຽງແຕ່ຕົວເລກລະຫວ່າງ 1-99999 ທີ່ຖືກອະນຸຍາດ</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -506,7 +508,7 @@
     </message>
     <message>
         <source>Backup failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update installation successful</source>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">कुप्लेस</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Uitklappen</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Forumgebruikers met niveau 2 of hoger kunnen deelnemen aan de bètatest.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Inklappen</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Alleen getallen tussen de 1 en 99999 zijn toegestaan</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Rozwiń</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Użytkownicy forum na poziomie 2 lub wyższym mogą dołączyć do testów Beta i uzyskać najnowsze aktualizacje.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Zwiń</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Dozwolone są tylko liczby w zakresie 1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Expandir</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Os usuários com nível 2 ou superior no fórum podem participar do programa beta para testar as últimas atualizações.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Recolher</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Somente números entre 1-99999 são permitidos</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Zgjeroje</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Përdorues forumi të nivelit 2 e më sipër mund të bëhen pjesë e testimeve beta, që të marrin përditësimet më të reja.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Palose</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Lejohen vetëm numra mes 1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -396,7 +398,7 @@
     </message>
     <message>
         <source>updatelog</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Log export failed, please try again</source>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -90,7 +92,7 @@
     </message>
     <message>
         <source>Export to desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -247,7 +249,7 @@
     </message>
     <message>
         <source>The system has enabled auto recovery function and does not support updates. If you have any questions, please contact the enterprise administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -364,16 +366,16 @@
         <translation>Genişlet</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Seviye 2 ve üzeri forum kullanıcıları son güncellemeleri almak için beta testine katılabilir.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Daralt</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Sadece 1-99999 arasındaki sayılara izin verilir</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>Розгорнути</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>Користувачі форуму рівня 2 та вищих рівнів можуть долучатися до тестування для отримання найсвіжіших оновлень.</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>Згорнути</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>Можна використовувати лише числа у діапазоні 1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -366,15 +366,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation type="unfinished">Thu gọn</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>CheckUpdate</name>
     <message>
@@ -364,16 +366,16 @@
         <translation>展开</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>论坛2级及以上用户可加入内测，获取最新更新</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>只允许输入1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -364,16 +366,16 @@
         <translation>展開</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>論壇2級及以上用户可加入內測，獲取最新更新</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>只允許輸入1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -446,7 +448,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -1,9 +1,11 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
 <context>
     <name>CheckUpdate</name>
     <message>
         <source>Last check: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -154,12 +156,12 @@
     </message>
     <message>
         <source>, </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>中文逗号不需要空格，英文逗号需要空格For more details, please visit</extra-content_explain>
     </message>
     <message>
         <source>for more details, please visit </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
         <extra-content_explain>这句话后面会带上一个超链接，各语言自行决定末尾需不需要加空格</extra-content_explain>
     </message>
 </context>
@@ -364,16 +366,16 @@
         <translation>展開</translation>
     </message>
     <message>
-        <source>Forum users at level 2 and above can join the beta test to receive the latest updates.</source>
-        <translation>論壇2級及以上使用者可加入內測，獲取最新更新</translation>
-    </message>
-    <message>
         <source>Collapse</source>
         <translation>收起</translation>
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>只允許輸入1-99999</translation>
+    </message>
+    <message>
+        <source>Join the internal testing channel to get deepin latest updates.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -446,7 +448,7 @@
     </message>
     <message>
         <source>Update size: </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update download failed</source>


### PR DESCRIPTION
Changed the description text for the internal testing channel option from "Forum users at level 2 and above can join the beta test to receive the latest updates" to "Join the internal testing channel to get deepin latest updates".

Log: Updated testing channel description to be more inclusive and clear

Influence:
1. Verify the new description text appears correctly in the update settings
2. Check that translations are properly handled for the new message
3. Ensure the testing channel functionality still works as expected

fix: 更新测试通道描述文本

将内部测试通道选项的描述从"论坛2级及以上用户可加入内测，获取最新更新"改
为"加入内部测试通道获取deepin最新更新"。

Log: 更新测试通道描述使其更包容清晰

Influence:
1. 验证更新设置中正确显示新的描述文本
2. 检查新消息的翻译处理是否正确

PMS: STORY-39137