### PR TITLE
fix: adjust widget size after update completion

### DIFF
--- a/src/dde-update/updatewidget.cpp
+++ b/src/dde-update/updatewidget.cpp
@@ -437,6 +437,7 @@ void UpdateCompleteWidget::showSuccessFrame()
     });
 
     collapseLogWidget();
+    m_contentWidget->adjustSize();
 }
 
 void UpdateCompleteWidget::showErrorFrame(UpdateModel::UpdateError error)


### PR DESCRIPTION
1. Added m_contentWidget->adjustSize() call after collapseLogWidget() in showSuccessFrame()
2. This ensures proper widget resizing when the log section collapses
3. Prevents potential layout issues or empty spaces after update completion

fix: 更新完成后调整控件大小

1. 在showSuccessFrame()中的collapseLogWidget()后添加了 m_contentWidget->adjustSize()调用
2. 确保当日志部分折叠时正确调整控件大小
3. 防止更新完成后可能出现的布局问题或空白区域

PMS: BUG-321487 PMS: BUG-324587