### PR TITLE
fix: correct error message display for update failures

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -368,6 +368,10 @@ UpdateErrorType UpdateWorker::analyzeJobErrorMessage(const QString& jobDescripti
         return DpkgInterrupted;
     }
 
+    if (errorType.contains("dpkgError", Qt::CaseInsensitive)) {
+        return DpkgError;
+    }
+
     if (errorType.contains("platformUnreachable", Qt::CaseInsensitive)) {
         return PlatformUnreachable;
     }
@@ -488,7 +492,6 @@ void UpdateWorker::createCheckUpdateJob(const QString& jobPath)
 
     connect(m_checkUpdateJob, &UpdateJobDBusProxy::StatusChanged, this, &UpdateWorker::onCheckUpdateStatusChanged);
     connect(m_checkUpdateJob, &UpdateJobDBusProxy::ProgressChanged, m_model, &UpdateModel::setCheckUpdateProgress, Qt::QueuedConnection);
-
 
     m_checkUpdateJob->ProgressChanged(m_checkUpdateJob->progress());
     m_checkUpdateJob->StatusChanged(m_checkUpdateJob->status());

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -211,7 +211,7 @@ DccObject {
                 dialogloader.active = true
             }
 
-            updateTips: dccData.model().downloadFailedTips
+            updateTips: dccData.model().installFailedTips
             btnActions: [ qsTr("Continue Update") ]
 
             onBtnClicked: function(index, updateType) {
@@ -325,7 +325,7 @@ DccObject {
             updateListModels: dccData.model().downloadFailedListModel
             updateTitle: qsTr("Update download failed")
             btnActions: [ qsTr("Retry") ]
-            updateTips: dccData.model().installFailedTips
+            updateTips: dccData.model().downloadFailedTips
             busyState: dccData.model().upgradeWaiting
             updateListEnable: !dccData.model().upgradeWaiting
 


### PR DESCRIPTION
1. Added new DpkgError case in error type analysis
2. Swapped downloadFailedTips and installFailedTips properties to show correct messages for each failure type

Log: Fixed incorrect error messages being shown for update failures

Influence:
1. Test update scenarios that trigger different error types
2. Verify correct error messages are shown for download vs install failures
3. Check DpkgError handling in update process
4. Validate error message consistency across different failure modes

fix: 修正更新失败时的错误信息显示

1. 在错误类型分析中添加了新的DpkgError情况
2. 交换了downloadFailedTips和installFailedTips属性，为每种失败类型显示正 确的消息

Log: 修复更新失败时显示错误信息的问题

Influence:
1. 测试触发不同错误类型的更新场景
2. 验证下载失败和安装失败时显示正确的错误信息
3. 检查更新过程中对DpkgError的处理
4. 验证不同失败模式下的错误消息一致性

PMS: BUG-327329