### PR TITLE
fix: add tooltip for truncated checkbox text

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -255,8 +255,12 @@ DccObject {
                 D.CheckBox {
                     id: inactiveDownloadCheckBox
                     Layout.leftMargin: 14
+                    Layout.fillWidth: true
+                    ToolTip {
+                        visible: inactiveDownloadCheckBox.width < inactiveDownloadCheckBox.implicitWidth && inactiveDownloadCheckBox.hovered
+                        text: inactiveDownloadCheckBox.text
+                    }
                     text: dccObj.displayName
-                    font.pixelSize: 12
                     checked: {
                         if (!dccData.model().autoDownloadUpdates)
                             return false


### PR DESCRIPTION
Added a tooltip that appears when the checkbox text is truncated and hovered over. The tooltip shows the full text of the checkbox with a delay of 500ms and disappears after 3000ms. Also adjusted the layout to fill available width.

This change improves usability by ensuring users can always read the full checkbox label even when it's truncated due to space constraints. The tooltip only appears when needed (when text is truncated) and provides a smooth user experience with appropriate timing.

Log: Added tooltip for truncated checkbox text in update settings

Influence:
1. Test checkbox behavior with long text that gets truncated
2. Verify tooltip appears only when text is truncated
3. Test hover behavior and tooltip positioning

fix: 为截断的复选框文本添加提示工具

当复选框文本因空间不足被截断且鼠标悬停时，添加显示完整文本的提示工具。工
具提示显示完整复选框文本，延迟500毫秒出现，3000毫秒后自动消失。同时调整
布局以填充可用宽度。

此改进确保用户始终能够查看完整的复选框标签，即使因空间限制被截断。提示工
具仅在需要时（文本被截断时）出现，并通过适当的计时提供流畅的用户体验。

Log: 在更新设置中为截断的复选框文本添加提示工具

Influence:
1. 测试带有长文本被截断的复选框行为
2. 验证提示工具仅在文本被截断时出现
3. 测试悬停行为和提示工具定位

PMS: BUG-324039