### PR TITLE
fix: improve UI consistency and layout in update module

### DIFF
--- a/src/dcc-update-plugin/qml/CheckUpdate.qml
+++ b/src/dcc-update-plugin/qml/CheckUpdate.qml
@@ -50,13 +50,12 @@ ColumnLayout {
                 Layout.alignment: Qt.AlignHCenter
                 width: implicitWidth
                 text: dccData.model().checkUpdateErrTips
-                font.pixelSize: 12
+                font: D.DTK.fontManager.t8
             }
 
             D.Button {
                 Layout.alignment: Qt.AlignHCenter
                 implicitWidth: 200
-                font.pixelSize: 14
                 visible: text.length !== 0
                 text: dccData.model().checkBtnText
                 onClicked: {
@@ -68,7 +67,7 @@ ColumnLayout {
                 visible: dccData.model().checkUpdateStatus === Common.Updated
                 Layout.alignment: Qt.AlignHCenter
                 text: qsTr("Last check: ") + dccData.model().lastCheckUpdateTime
-                font.pixelSize: 10
+                font: D.DTK.fontManager.t10
             }
         }
    }

--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -145,7 +145,7 @@ ColumnLayout {
                     implicitWidth: 210
                 }
 
-                D.ActionButton {
+                D.ToolButton {
                     id: pauseIcon
                     icon.name: isPauseOrNot ? "update_start" : "update_pause"
                     icon.width: 24
@@ -163,7 +163,7 @@ ColumnLayout {
                     }
                 }
 
-                D.ActionButton {
+                D.ToolButton {
                     id: stopIcon
                     icon.name: "update_stop"
                     icon.width: 24

--- a/src/dcc-update-plugin/qml/UpdateDisable.qml
+++ b/src/dcc-update-plugin/qml/UpdateDisable.qml
@@ -34,7 +34,7 @@ ColumnLayout {
             D.Label {
                 Layout.fillWidth: true
                 text: dccData.model().updateDisabledTips
-                font.pixelSize: 12
+                font: D.DTK.fontManager.t8
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap

--- a/src/dcc-update-plugin/qml/UpdateLogDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateLogDialog.qml
@@ -24,6 +24,7 @@ D.DialogWindow {
         spacing: 10
 
         D.Label {
+            id: titleLabel
             Layout.alignment: Qt.AlignHCenter
             text: title
             font: D.DTK.fontManager.t6
@@ -34,7 +35,7 @@ D.DialogWindow {
         ScrollView {
             id: scrollView
             Layout.fillWidth: true
-            Layout.preferredHeight: 240
+            Layout.preferredHeight: root.height - titleLabel.height - buttonRow.height - 80
 
             // 滚动条策略
             ScrollBar.vertical.policy: ScrollBar.AsNeeded
@@ -56,6 +57,9 @@ D.DialogWindow {
 
         // 按钮行
         RowLayout {
+            id: buttonRow
+            spacing: 10
+            
             Button {
                 Layout.fillWidth: true
                 text: qsTr("Close")

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -178,7 +178,6 @@ DccObject {
             page: RowLayout {
                 D.LineEdit {
                     id: lineEdit
-                    font.pixelSize: 14
                     maximumLength: 5
                     validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
                     alertText: qsTr("Only numbers between 1-99999 are allowed")
@@ -211,7 +210,6 @@ DccObject {
 
                 D.Label {
                     text: "KB/S"
-                    font.pixelSize: 14
                 }
             }
         }


### PR DESCRIPTION
1. Replaced hardcoded font sizes with DTK font manager styles (t8, t10) for better consistency
2. Changed ActionButton to ToolButton for pause/stop controls to match design system
3. Improved UpdateLogDialog layout calculation to be dynamic based on window height
4. Removed redundant font size settings that were overriding DTK styles
5. Added proper spacing in button rows for better visual hierarchy

Log:
1. Updated font styles across update module for consistency
2. Changed button types in update controls
3. Improved dialog layout responsiveness

Influence:
1. Verify all text displays correctly with new font styles
2. Check button functionality in update controls remains unchanged
3. Test UpdateLogDialog resizing behavior
4. Validate layout in different screen sizes
5. Confirm numeric input validation in speed limit settings

fix: 优化更新模块UI一致性和布局

1. 使用DTK字体管理器样式(t8, t10)替代硬编码字体大小，提高一致性
2. 将暂停/停止控制按钮从ActionButton改为ToolButton以符合设计系统
3. 改进更新日志对话框布局计算，基于窗口高度动态调整
4. 移除了覆盖DTK样式的冗余字体大小设置
5. 在按钮行添加适当间距，优化视觉层次

Log:
1. 更新模块字体样式统一调整
2. 更新控制按钮类型变更
3. 对话框布局响应性改进

Influence:
1. 验证所有文本在新字体样式下显示正确
2. 检查更新控制按钮功能保持不变
3. 测试更新日志对话框的调整大小行为
4. 在不同屏幕尺寸下验证布局
5. 确认速度限制设置中的数字输入验证

PMS: BUG-327335 BUG-324027