### PR TITLE
fix: fix update description paragraph spacing

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -93,11 +93,12 @@ Rectangle {
                             horizontalAlignment: Text.AlignLeft
                             Layout.fillWidth: true
                             font: D.DTK.fontManager.t8
-                            text: model.titleDescription
+                            textFormat: Text.RichText
+                            text: model.titleDescription.replace(/<p>/g, "<p style='margin:0'>")
                             wrapMode: Text.WordWrap
                             onLinkActivated: (link)=> {
                                 dccData.work().openUrl(link)
-                            }  
+                            }
                         }
 
                         D.Label {


### PR DESCRIPTION
Fixed paragraph spacing issue in update descriptions by adding margin styling to paragraph tags. The update descriptions were displaying with excessive spacing between paragraphs due to default HTML paragraph styling. This change adds inline CSS to remove margins from paragraph elements, making the text display more compact and readable in the update list interface.

Log: Fixed excessive spacing in update description paragraphs

Influence:
1. Verify update descriptions display without excessive spacing between paragraphs
2. Check that rich text formatting still works correctly
3. Test link activation functionality remains intact
4. Ensure text wrapping behaves as expected

fix: 修复更新描述段落间距问题

通过为段落标签添加边距样式修复了更新描述中的段落间距问题。更新描述由于默
认的HTML段落样式显示时段落间距过大。此更改添加了内联CSS来移除段落元素的
边距，使文本在更新列表界面中显示更加紧凑和可读。

Log: 修复了更新描述段落间距过大的问题

Influence:
1. 验证更新描述显示时段落间距正常
2. 检查富文本格式功能仍然正常工作
3. 测试链接激活功能保持正常
4. 确保文本换行行为符合预期

PMS: BUG-322233