### PR TITLE
refactor: improve DBus call handling and return values

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -112,7 +112,7 @@ LastoreUpdatePackagesInfo UpdateDBusProxy::classifiedUpdatablePackages()
     return packagesInfo;
 }
 
-double UpdateDBusProxy::GetCheckIntervalAndTime(QString &out1)
+QString UpdateDBusProxy::GetCheckIntervalAndTime()
 {
     qCDebug(logCommon) << "Getting check interval and time";
     QList<QVariant> argumentList;
@@ -121,12 +121,13 @@ double UpdateDBusProxy::GetCheckIntervalAndTime(QString &out1)
                                                 QStringLiteral("GetCheckIntervalAndTime"),
                                                 argumentList);
     if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().count() == 2) {
-        out1 = qdbus_cast<QString>(reply.arguments().at(1));
-        qCDebug(logCommon) << "Check time:" << out1;
+        QString checkTime = qdbus_cast<QString>(reply.arguments().at(1));
+        qCDebug(logCommon) << "Check time:" << checkTime;
+        return checkTime;
     } else if (reply.type() == QDBusMessage::ErrorMessage) {
         qCWarning(logCommon) << "GetCheckIntervalAndTime failed: " << reply.errorMessage();
     }
-    return qdbus_cast<double>(reply.arguments().at(0));
+    return {};
 }
 
 bool UpdateDBusProxy::autoDownloadUpdates()

--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -35,7 +35,7 @@ public:
     bool updateNotify();
     void SetUpdateNotify(bool in0);
     LastoreUpdatePackagesInfo classifiedUpdatablePackages();
-    double GetCheckIntervalAndTime(QString &out1);
+    QString GetCheckIntervalAndTime();
 
     Q_PROPERTY(bool AutoDownloadUpdates READ autoDownloadUpdates NOTIFY AutoDownloadUpdatesChanged)
     bool autoDownloadUpdates();

--- a/src/dde-abrecovery/recoverydialog.cpp
+++ b/src/dde-abrecovery/recoverydialog.cpp
@@ -170,12 +170,14 @@ void Manage::requestReboot()
     qCDebug(logUpdateRecovery) << "Requesting system reboot";
     QDBusPendingCall call = m_updateDBusProxy->Poweroff(false);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, [this, call] {
-        if (!call.isError()) {
+    connect(watcher, &QDBusPendingCallWatcher::finished, [this, watcher] {
+        QDBusPendingReply<void> reply = watcher->reply();
+        if (!reply.isError()) {
             qCInfo(logUpdateRecovery) << "System reboot request successful";
         } else {
-            qCWarning(logUpdateRecovery) << "System reboot request failed:" << call.error().message();
+            qCWarning(logUpdateRecovery) << "System reboot request failed:" << reply.error().message();
         }
+        watcher->deleteLater();
         exitApp();
     });
 }


### PR DESCRIPTION
1. Changed GetCheckIntervalAndTime to return QString instead of using output parameter
2. Fixed DBus call watcher lambdas to properly handle replies using watcher->reply()
3. Added error handling for empty check time return values
4. Ensured proper resource cleanup with watcher->deleteLater() in all cases

refactor: 改进 DBus 调用处理和返回值

1. 将 GetCheckIntervalAndTime 改为返回 QString 而不是使用输出参数
2. 修复 DBus 调用观察器的 lambda 函数，正确使用 watcher->reply() 处理 回复
3. 为空的检查时间返回值添加错误处理
4. 确保在所有情况下都正确使用 watcher->deleteLater() 进行资源清理