### PR TITLE
fix: add update notification red dot indicator

### DIFF
--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -28,6 +28,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(QString updateDisabledTips READ updateDisabledTips NOTIFY updateDisabledTipsChanged FINAL)
     Q_PROPERTY(bool batterIsOK READ batterIsOK NOTIFY batterIsOKChanged FINAL)
     Q_PROPERTY(int lastStatus READ lastStatus  NOTIFY lastStatusChanged FINAL)
+    Q_PROPERTY(bool isUpdatable READ isUpdatable  NOTIFY isUpdatableChanged FINAL)
 
     // ---------------检查更新页面数据---------------
     Q_PROPERTY(bool showCheckUpdate READ showCheckUpdate NOTIFY showCheckUpdateChanged FINAL)

--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -12,6 +12,19 @@ import org.deepin.dcc.update 1.0
 
 DccObject {
 
+    // 更新通知小红点
+    function updateNotifyRedPoint() {
+        if (dccData.model().isUpdateDisabled || !dccData.model().updateNotify || !dccData.model().isUpdatable) {
+            dccModule.badge = 0
+            return
+        }
+        dccModule.badge = 1
+    }
+
+    Component.onCompleted: {
+        updateNotifyRedPoint()
+    }
+
     // 处理更新模块激活和子组件变化的连接
     Connections {
         // 标识是否已经检查过更新
@@ -40,6 +53,13 @@ DccObject {
             if (dccModule.hasView && !dccData.model().isUpdateDisabled) {
                 dccData.work().checkNeedDoUpdates()
             }
+            updateNotifyRedPoint()
+        }
+        function onUpdateNotifyChanged() {
+            updateNotifyRedPoint()
+        }
+        function onIsUpdatableChanged() {
+            updateNotifyRedPoint()
         }
     }
 


### PR DESCRIPTION
Added update notification red dot feature to show when updates are available
1. Added isUpdatable Q_PROPERTY to UpdateModel to track update availability status
2. Implemented updateNotifyRedPoint function in QML to control badge display
3. Added connections to updateNotify and isUpdatable signals to dynamically update badge
4. Initial badge state is set during component completion
5. Red dot appears when updates are available, notifications are enabled, and update is not disabled

Log: Added update notification red dot indicator

Influence:
1. Test red dot appears when updates are available and notifications enabled
2. Verify red dot disappears when updates are disabled
3. Test red dot updates dynamically when update status changes
4. Verify badge value changes correctly (0 for hidden, 1 for visible)
5. Test initial state when component loads

fix: 添加更新通知小红点功能

添加更新通知小红点功能，用于显示有可用更新时的视觉提示
1. 在UpdateModel中添加isUpdatable Q_PROPERTY属性来跟踪更新可用状态
2. 在QML中实现updateNotifyRedPoint函数来控制徽章显示
3. 添加对updateNotify和isUpdatable信号的连接以实现动态更新徽章
4. 组件完成时设置初始徽章状态
5. 当有可用更新、通知启用且更新未禁用时显示小红点

Log: 新增更新通知小红点指示器

Influence:
1. 测试有可用更新且通知启用时小红点是否显示
2. 验证更新禁用时小红点是否消失
3. 测试更新状态变化时小红点动态更新
4. 验证徽章值正确变化（0表示隐藏，1表示显示）
5. 测试组件加载时的初始状态

PMS: BUG-314519