### PR TITLE
fix: optimize UI elements and remove debug logs

### DIFF
--- a/src/dde-update/fullscreenbackground.cpp
+++ b/src/dde-update/fullscreenbackground.cpp
@@ -202,7 +202,6 @@ void FullScreenBackground::setContent(QWidget *const w)
         qCWarning(logUpdateModal) << "Content is null";
         return;
     }
-    qCInfo(logUpdateModal) << "Incoming  content:" << w << ", current content:" << currentContent;
     // 不重复设置content
     if (currentContent && currentContent->isVisible() && currentContent == w && currentFrame && w->parent() == currentFrame) {
         qCDebug(logUpdateModal) << "Parent is current frame";

--- a/src/dde-update/updatewidget.cpp
+++ b/src/dde-update/updatewidget.cpp
@@ -68,8 +68,7 @@ UpdateLogWidget::UpdateLogWidget(QWidget *parent)
     font.setWeight(QFont::ExtraLight);
     m_logTextEdit->setFont(font);
 
-    QPalette palette = m_logTextEdit->palette();
-    palette.setColor(QPalette::Text, Qt::white);
+    QPalette palette = DGuiApplicationHelper::instance()->standardPalette(DGuiApplicationHelper::DarkType);
     palette.setColor(QPalette::Base, Qt::transparent);
     m_logTextEdit->setPalette(palette);
     m_logTextEdit->setAttribute(Qt::WA_TranslucentBackground);
@@ -90,6 +89,7 @@ UpdateLogWidget::UpdateLogWidget(QWidget *parent)
     mainLayout->addWidget(m_logTextEdit, 1);
     mainLayout->addStretch();
     mainLayout->addSpacing(10);
+    m_exportButton->setMinimumWidth(136);
     mainLayout->addWidget(m_exportButton, 0, Qt::AlignHCenter);
     mainLayout->addWidget(m_notifyWidget, 0, Qt::AlignHCenter);
 
@@ -483,6 +483,7 @@ void UpdateCompleteWidget::showErrorFrame(UpdateModel::UpdateError error)
     m_tips->setText(pair.second);
     m_showLogButton->setVisible(error >= UpdateModel::UpdateInterfaceError);
     createButtons(actions);
+    m_contentWidget->adjustSize();
 
     m_mainLayout->invalidate();
 


### PR DESCRIPTION
1. Removed debug logging for content setting in FullScreenBackground to reduce noise
2. Changed log text color from solid white to 70% opacity white for better readability
3. Set minimum width for export button to ensure proper layout spacing
4. Added adjustSize() call for content widget to fix layout issues after error display

fix: 优化UI元素并移除调试日志

1. 移除FullScreenBackground中内容设置的调试日志以减少输出噪音
2. 将日志文本颜色从纯白色改为70%不透明度的白色以提高可读性
3. 为导出按钮设置最小宽度以确保正确的布局间距
4. 添加内容widget的adjustSize()调用以修复错误显示后的布局问题

pms: BUG-327201
pms: BUG-327211