### PR TITLE
fix: optimize system activation state refresh

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -123,7 +123,6 @@ public Q_SLOTS:
     void onRemovePackageStatusChanged(const QString& value);
 
 Q_SIGNALS:
-    void systemActivationChanged(bool systemActivation);
     void requestCloseTestingChannel();
     void startDoUpgrade();
 


### PR DESCRIPTION
Removed asynchronous signal emission for system activation state changes to improve response time. Previously, systemActivationChanged signal was emitted with Qt::QueuedConnection which caused delays in UI updates. Now directly call m_model->setSystemActivation() method to synchronously update the model state.

The change eliminates the need for QtConcurrent::run in onLicenseStateChange() slot, simplifying the code and making activation state updates immediate instead of queued. This addresses the performance issue where system activation status refresh was too slow through asynchronous signals.

Log: Improved system activation status refresh speed

Influence:
1. Test system activation state changes in real-time
2. Verify UI updates immediately reflect activation status
3. Check that community systems still show as activated
4. Test license state changes through D-Bus interface
5. Verify power change and system version updates still work correctly

fix: 优化系统激活状态刷新性能

移除了系统激活状态变化的异步信号发射以提高响应速度。之前使用
Qt::QueuedConnection 发射 systemActivationChanged 信号导致 UI 更新延迟。 现在直接调用 m_model->setSystemActivation() 方法同步更新模型状态。

此更改消除了在 onLicenseStateChange() 槽中使用 QtConcurrent::run 的需 要，简化了代码并使激活状态更新变为即时而非排队处理。这解决了通过异步信号
刷新系统激活状态太慢的性能问题。

Log: 提升系统激活状态刷新速度

Influence:
1. 测试系统激活状态的实时变化
2. 验证 UI 立即反映激活状态更新
3. 检查社区系统仍显示为已激活
4. 测试通过 D-Bus 接口的许可证状态变化
5. 验证电源变更和系统版本更新功能仍正常工作

PMS: BUG-329151