### PR TITLE
fix: keep time inputs always enabled

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -279,12 +279,10 @@ DccObject {
 
                     D.Label {
                        text: qsTr("Start at")
-                       enabled: inactiveDownloadCheckBox.checked
                     }
 
                     DccTimeRange {
                         id: beginTimeRange
-                        enabled: inactiveDownloadCheckBox.checked
                         hour: dccData.model().beginTime.split(':')[0]
                         minute: dccData.model().beginTime.split(':')[1]
                         onTimeChanged: {
@@ -295,12 +293,10 @@ DccObject {
                     D.Label {
                         Layout.leftMargin: 10
                         text: qsTr("End at")
-                        enabled: inactiveDownloadCheckBox.checked
                     }
 
                     DccTimeRange {
                         id: endTimeRange
-                        enabled: inactiveDownloadCheckBox.checked
                         hour: dccData.model().endTime.split(':')[0]
                         minute: dccData.model().endTime.split(':')[1]
                         onTimeChanged: {


### PR DESCRIPTION
Removed the enabled property binding from time input labels and DccTimeRange components that were previously tied to inactiveDownloadCheckBox.checked state. This change ensures that time input fields remain accessible regardless of the checkbox state, allowing users to view and modify time settings even when the inactive download feature is disabled.

Log: Time input fields are now always enabled regardless of inactive download setting state

Influence:
1. Verify that time input fields are always enabled and interactive
2. Test that time values can be modified regardless of checkbox state
3. Check that time display remains visible when checkbox is unchecked
4. Validate that time changes are properly saved in both checkbox states
5. Test the overall functionality of the inactive download feature with time inputs

fix: 保持时间输入框始终可用

移除了时间输入标签和DccTimeRange组件中之前与
inactiveDownloadCheckBox.checked状态绑定的enabled属性。此更改确保无论复 选框状态如何，时间输入字段都保持可访问，允许用户即使在非活动下载功能禁用
时也能查看和修改时间设置。

Log: 时间输入框现在始终保持可用，不受非活动下载设置状态影响

Influence:
1. 验证时间输入框始终可用且可交互
2. 测试无论复选框状态如何都能修改时间值
3. 检查复选框未选中时时间显示仍然可见
4. 验证时间更改在两种复选框状态下都能正确保存
5. 测试带有时间输入的非活动下载功能的整体功能

PMS: BUG-331513