### PR TITLE
fix: adjust privacy label layout in update module

### DIFF
--- a/src/dcc-update-plugin/qml/updateMain.qml
+++ b/src/dcc-update-plugin/qml/updateMain.qml
@@ -405,15 +405,19 @@ DccObject {
             Rectangle {
                 color: 'transparent'
                 Layout.fillWidth: true
-                Layout.preferredHeight: 40
+                Layout.preferredHeight: privacyLabel.implicitHeight + 20
                 D.Label {
+                    id: privacyLabel
                     anchors.left: parent.left
                     anchors.leftMargin: 10
+                    anchors.right: parent.right
+                    anchors.rightMargin: 10
                     anchors.verticalCenter: parent.verticalCenter
                     font: D.DTK.fontManager.t10
                     opacity: 0.7
                     textFormat: Text.RichText
                     text: dccData.model().privacyAgreementText()
+                    wrapMode: Text.Wrap
                     onLinkActivated: (link)=> {
                         dccData.work().openUrl(link)
                     }


### PR DESCRIPTION
Fixed the privacy agreement label layout in the update module to properly handle text wrapping and dynamic height. The changes include:
1. Changed Layout.preferredHeight from fixed 40px to dynamic height based on text content (implicitHeight + 20px padding)
2. Added right margin constraint to prevent text from extending beyond container boundaries
3. Added wrapMode property to enable text wrapping for longer privacy agreement texts
4. Added unique id for the label to reference its implicitHeight property

These changes ensure that privacy agreement text is properly displayed without truncation, especially for longer texts that require wrapping, while maintaining proper spacing and alignment within the update interface.

Log: Fixed privacy agreement text display issue in update module

Influence:
1. Test update module interface with various privacy agreement text lengths
2. Verify text wrapping functionality works correctly
3. Check that the label height adjusts dynamically based on content
4. Confirm right margin constraint prevents text overflow
5. Test link activation functionality remains working
6. Verify overall layout stability with different text content

fix: 调整更新模块中隐私标签布局

修复了更新模块中隐私协议标签的布局问题，以正确处理文本换行和动态高度。更
改包括：
1. 将Layout.preferredHeight从固定的40px改为基于文本内容的动态高度 （implicitHeight + 20px内边距）
2. 添加右边距约束以防止文本超出容器边界
3. 添加wrapMode属性以支持较长隐私协议文本的换行显示
4. 为标签添加唯一id以便引用其implicitHeight属性

这些更改确保隐私协议文本能够正确显示而不会被截断，特别是对于需要换行的较
长文本，同时保持更新界面内的适当间距和对齐。

Log: 修复更新模块中隐私协议文本显示问题

Influence:
1. 测试更新模块界面在不同长度隐私协议文本下的显示效果
2. 验证文本换行功能正常工作
3. 检查标签高度是否根据内容动态调整
4. 确认右边距约束有效防止文本溢出
5. 测试链接激活功能仍然正常工作
6. 验证不同文本内容下的整体布局稳定性

PMS: BUG-334869