### PR TITLE
fix: fix check update status display logic

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -444,10 +444,7 @@ void UpdateWorker::checkNeedDoUpdates()
         return;
     }
 
-    m_model->setShowCheckUpdate(!m_model->isUpdatable());
-    if (!m_model->isUpdatable()) {
-        m_model->setCheckUpdateStatus(UpdatesStatus::Updated);
-    }
+    m_model->setShowCheckUpdate(m_model->checkUpdateStatus() == UpdatesStatus::CheckingFailed || !m_model->isUpdatable());
 }
 
 void UpdateWorker::doCheckUpdates()

--- a/src/dcc-update-plugin/qml/CheckUpdate.qml
+++ b/src/dcc-update-plugin/qml/CheckUpdate.qml
@@ -27,12 +27,11 @@ ColumnLayout {
                 id: checkUpdateIcon
                 Layout.alignment: Qt.AlignHCenter
                 name: dccData.model().checkUpdateIcon
-                palette: D.DTK.makeIconPalette(checkUpdateIcon.palette)
                 theme: D.DTK.themeType
                 sourceSize {
                     width: 134
                     height: 134
-                }                
+                }
             }
 
             D.ProgressBar {


### PR DESCRIPTION
1. Modified checkNeedDoUpdates() to properly handle check update status display
2. Changed condition to show check update button when status is CheckingFailed OR system is not updatable
3. Removed redundant status setting that was overriding the actual check status
4. Fixed palette assignment in QML to prevent potential display issues

Log: Fixed update check status display when check fails

Influence:
1. Test update check functionality when network is available
2. Test update check when network is unavailable to verify failed status display
3. Verify check update button visibility in different scenarios
4. Test UI consistency when switching between different update states
5. Verify no regression in normal update flow

fix: 修复检查更新状态显示逻辑

1. 修改 checkNeedDoUpdates() 方法以正确处理检查更新状态显示
2. 更改条件，在状态为检查失败或系统不可更新时显示检查更新按钮
3. 移除冗余的状态设置，避免覆盖实际检查状态
4. 修复 QML 中的调色板分配，防止可能的显示问题

Log: 修复检查更新失败时的状态显示问题

Influence:
1. 测试网络可用时的更新检查功能
2. 测试网络不可用时检查更新失败状态的显示
3. 验证不同场景下检查更新按钮的可见性
4. 测试在不同更新状态间切换时的界面一致性
5. 确保正常更新流程没有回归问题

PMS: BUG-335237