### PR TITLE
fix: prevent DBus signal infinite loop in QML bindings

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -52,7 +52,9 @@ DccObject {
             page: D.Switch {
                 checked: dccData.model().functionUpdate
                 onCheckedChanged: {
-                    dccData.work().setFunctionUpdate(checked)
+                    if (checked !== dccData.model().functionUpdate) {
+                        dccData.work().setFunctionUpdate(checked)
+                    }
                 }
             }
         }
@@ -68,7 +70,9 @@ DccObject {
             page: D.Switch {
                 checked: dccData.model().securityUpdate
                 onCheckedChanged: {
-                    dccData.work().setSecurityUpdate(checked)
+                    if (checked !== dccData.model().securityUpdate) {
+                        dccData.work().setSecurityUpdate(checked)
+                    }
                 }
             }
         }
@@ -84,7 +88,9 @@ DccObject {
             page: D.Switch {
                 checked: dccData.model().thirdPartyUpdate
                 onCheckedChanged: {
-                    dccData.work().setThirdPartyUpdate(checked)
+                    if (checked !== dccData.model().thirdPartyUpdate) {
+                        dccData.work().setThirdPartyUpdate(checked)
+                    }
                 }
             }
         }
@@ -183,7 +189,9 @@ DccObject {
                 page: D.Switch {
                     checked: dccData.model().downloadSpeedLimitEnabled
                     onCheckedChanged: {
-                        dccData.work().setDownloadSpeedLimitEnabled(checked)
+                        if (checked !== dccData.model().downloadSpeedLimitEnabled) {
+                            dccData.work().setDownloadSpeedLimitEnabled(checked)
+                        }
                     }
                 }
             }
@@ -256,7 +264,9 @@ DccObject {
                 page: D.Switch {
                     checked: dccData.model().autoDownloadUpdates
                     onCheckedChanged: {
-                        dccData.work().setAutoDownloadUpdates(checked)
+                        if (checked !== dccData.model().autoDownloadUpdates) {
+                            dccData.work().setAutoDownloadUpdates(checked)
+                        }
                     }
                 }
             }
@@ -286,7 +296,9 @@ DccObject {
                             return dccData.model().idleDownloadEnabled
                         }
                         onCheckedChanged: {
-                            dccData.work().setIdleDownloadEnabled(checked)
+                            if (checked !== dccData.model().idleDownloadEnabled) {
+                                dccData.work().setIdleDownloadEnabled(checked)
+                            }
                         }
                     }
 
@@ -352,7 +364,9 @@ DccObject {
                 page: D.Switch {
                     checked: dccData.model().updateNotify
                     onCheckedChanged: {
-                        dccData.work().setUpdateNotify(checked)
+                        if (checked !== dccData.model().updateNotify) {
+                            dccData.work().setUpdateNotify(checked)
+                        }
                     }
                 }
             }
@@ -366,7 +380,9 @@ DccObject {
                 page: D.Switch {
                     checked: dccData.model().autoCleanCache
                     onCheckedChanged: {
-                        dccData.work().setAutoCleanCache(checked)
+                        if (checked !== dccData.model().autoCleanCache) {
+                            dccData.work().setAutoCleanCache(checked)
+                        }
                     }
                 }
             }
@@ -423,7 +439,9 @@ DccObject {
                 page: D.Switch {
                     checked: dccData.model().smartMirrorSwitch
                     onCheckedChanged: {
-                        dccData.work().setSmartMirror(checked)
+                        if (checked !== dccData.model().smartMirrorSwitch) {
+                            dccData.work().setSmartMirror(checked)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Added conditional checks before calling DBus setter methods in all Switch components to avoid infinite signal loops.
Previously, when a Switch's checked property changed, it would immediately call the corresponding DBus setter method, which would emit a signal that updates the model property, causing the Switch's checked property to update again, creating an infinite loop. Now each onCheckedChanged handler checks if the new checked value differs from the current model value before calling the setter, breaking the circular dependency.

Log: Fixed potential UI freezes caused by infinite signal loops in update settings

Influence:
1. Test all toggle switches in update settings: function updates, security updates, third-party updates
2. Verify download speed limit toggle works correctly
3. Test auto-download updates toggle functionality

fix: 修复 QML 绑定中 DBus 信号无限循环问题

在所有 Switch 组件中调用 DBus setter 方法前添加条件检查，避免无限信号
循环。之前，当 Switch 的 checked 属性发生变化时，会立即调
用相应的 DBus setter 方法，这会发出更新模型属性的信号，导致 Switch 的
checked 属性再次更新，形成无限循环。现在每个 onCheckedChanged 处理程序
在调用 setter 之前检查新的 checked 值是否与当前模型值不同，从而打破循环
依赖。

Log: 修复了更新设置中无限信号循环可能导致的界面冻结问题

Influence:
1. 测试更新设置中的所有切换开关：功能更新、安全更新、第三方更新
2. 验证下载速度限制开关正常工作
3. 测试自动下载更新开关功能

PMS: BUG-354897
Change-Id: Id7969f3fdf0dd052494857ef6857f0f75426db56