### PR TITLE
fix: fix up key navigation in error and update complete dialogs

### DIFF
--- a/src/dde-update/checksystemwidget.cpp
+++ b/src/dde-update/checksystemwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -282,7 +282,24 @@ void ErrorFrame::createButtons(const QList<UpdateModel::UpdateAction> &actions)
 void ErrorFrame::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
-    case Qt::Key_Up:
+    case Qt::Key_Up: {
+        qCDebug(logUpdateModal) << "Up key pressed, switching to previous button";
+        if (m_actionButtons.size() > 1) {
+            int index = 0;
+            if (m_checkedButton) {
+                index = m_actionButtons.indexOf(m_checkedButton.data());
+                if (index <= 0)
+                    index = m_actionButtons.length() - 1;
+                else
+                    index--;
+
+                m_checkedButton->setChecked(false);
+            }
+            m_checkedButton = m_actionButtons.at(index);
+            m_checkedButton->setChecked(true);
+        }
+        break;
+    }
     case Qt::Key_Down:
     case Qt::Key_Tab: {
         qCDebug(logUpdateModal) << "Navigation key pressed, switching button selection";

--- a/src/dde-update/updatewidget.cpp
+++ b/src/dde-update/updatewidget.cpp
@@ -554,7 +554,24 @@ void UpdateCompleteWidget::collapseLogWidget()
 void UpdateCompleteWidget::keyPressEvent(QKeyEvent *event)
 {
     switch (event->key()) {
-    case Qt::Key_Up:
+    case Qt::Key_Up: {
+        qCDebug(logUpdateModal) << "Up key pressed, switching to previous button";
+        if (m_actionButtons.size() > 1) {
+            int index = 0;
+            if (m_checkedButton) {
+                index = m_actionButtons.indexOf(m_checkedButton.data());
+                if (index <= 0)
+                    index = m_actionButtons.length() - 1;
+                else
+                    index--;
+
+                m_checkedButton->setChecked(false);
+            }
+            m_checkedButton = m_actionButtons.at(index);
+            m_checkedButton->setChecked(true);
+        }
+        break;
+    }
     case Qt::Key_Down:
     case Qt::Key_Tab: {
         qCDebug(logUpdateModal) << "Navigation key pressed, switching button selection";


### PR DESCRIPTION
1. Fixed the up arrow key navigation behavior in ErrorFrame and UpdateCompleteWidget classes
2. Previously, the up key was handled together with down and tab keys, causing incorrect navigation
3. Now up key has its own separate case that properly cycles through buttons in reverse order
4. When pressing up key, it moves to the previous button, wrapping to the last button when at the first position

Log: Fixed keyboard navigation issue where pressing up arrow key did not work correctly in error dialogs and update completion screens

Influence:
1. Test up arrow key navigation in error dialogs with multiple action buttons
2. Test up arrow key navigation in update completion screens
3. Verify that button selection cycles correctly in both forward (down/ tab) and reverse (up) directions
4. Check that button focus wraps properly from first to last button when pressing up key

fix: 修复错误和更新完成对话框中的上键导航问题

1. 修复了ErrorFrame和UpdateCompleteWidget类中的上箭头键导航行为
2. 之前上键与下键和Tab键一起处理，导致导航不正确
3. 现在上键有独立的处理分支，能够正确反向循环遍历按钮
4. 按下上键时，移动到上一个按钮，当位于第一个位置时循环到最后一个按钮

Log: 修复了在错误对话框和更新完成界面中上箭头键导航不正确的问题

Influence:
1. 在具有多个操作按钮的错误对话框中测试上箭头键导航
2. 在更新完成界面中测试上箭头键导航
3. 验证按钮选择在正向（下键/Tab键）和反向（上键）方向都能正确循环
4. 检查按下上键时按钮焦点能否从第一个按钮正确循环到最后一个按钮

PMS: BUG-355669
Change-Id: Iaab4e9cdd1489c7423e5038a8675b388c2a14eed