### PR TITLE
chore: Refine private update tray comments and cleanup in V25

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -116,6 +116,7 @@ UpdateWorker::UpdateWorker(UpdateModel* model, QObject* parent)
     , m_lastoreDConfig(DConfig::create("org.deepin.dde.lastore", "org.deepin.dde.lastore", "", this))
     , m_model(model)
     , m_updateInter(new UpdateDBusProxy(this))
+    , m_updateAssistant(nullptr)
     , m_lastoreHeartBeatTimer(new QTimer(this))
     , m_logWatcherHelper(new LogWatcherHelper(m_updateInter, this))
     , m_machineid(std::nullopt)
@@ -128,7 +129,6 @@ UpdateWorker::UpdateWorker(UpdateModel* model, QObject* parent)
     , m_backupJob(nullptr)
     , m_installPackageJob(nullptr)
     , m_removePackageJob(nullptr)
-    , m_updateAssistant(nullptr)
 {
     qCDebug(logDccUpdatePlugin) << "Initializing UpdateWorker";
     qRegisterMetaType<UpdatesStatus>("UpdatesStatus");
@@ -1817,4 +1817,3 @@ void UpdateWorker::cleanUpgradeDeliveryCache()
         }
     });
 }
-

--- a/src/private-lastore-tray/commoniconbutton.cpp
+++ b/src/private-lastore-tray/commoniconbutton.cpp
@@ -50,6 +50,8 @@ CommonIconButton::CommonIconButton(QWidget *parent)
     m_animLabel2->setPixmap(QPixmap(":resources/private-lastore-active_16px.svg"));
     m_animLabel1->setFixedSize(Dock::DOCK_PLUGIN_ITEM_FIXED_SIZE);
     m_animLabel2->setFixedSize(Dock::DOCK_PLUGIN_ITEM_FIXED_SIZE);
+    m_animLabel1->hide();
+    m_animLabel2->hide();
 
     m_effect1->setOpacity(1.0);
     m_effect2->setOpacity(0.0);
@@ -83,6 +85,7 @@ void CommonIconButton::startRotate()
     if (!m_refreshTimer) {
         m_refreshTimer = new QTimer(this);
         m_refreshTimer->setInterval(70);
+        // 定时累加角度，驱动旋转绘制。
         connect(m_refreshTimer, &QTimer::timeout, this, &CommonIconButton::startRotate);
     }
     m_refreshTimer->start();
@@ -99,6 +102,10 @@ void CommonIconButton::stopRotate()
 
 void CommonIconButton::startAnimation()
 {
+    // 通过两张图标交替淡入淡出显示活动状态。
+    m_showingFirst = true;
+    m_effect1->setOpacity(1.0);
+    m_effect2->setOpacity(0.0);
     m_animLabel1->setVisible(true);
     m_animLabel2->setVisible(true);
     if (!m_animTimer->isActive()) {
@@ -144,6 +151,7 @@ void CommonIconButton::updatePalette()
 
 void CommonIconButton::switchIcon()
 {
+    // 切换当前显示的图标层并启动透明度动画。
     if (m_showingFirst) {
         m_fadeOutAnim->setTargetObject(m_effect1);
         m_fadeOutAnim->setStartValue(1.0);
@@ -192,6 +200,7 @@ void CommonIconButton::setIcon(const QString &icon, const QString &fallback, con
     QString tmp = icon;
     QString tmpFallback = fallback;
 
+    // 浅色主题下优先使用带 `-dark` 后缀的图标资源。
     static auto addDarkMark = [suffix] (QString &file) {
         if (file.contains(suffix)) {
             file.replace(suffix, "-dark" + suffix);
@@ -234,6 +243,11 @@ bool CommonIconButton::event(QEvent *e)
 void CommonIconButton::paintEvent(QPaintEvent *e)
 {
     QWidget::paintEvent(e);
+
+    if (m_animLabel1->isVisible() || m_animLabel2->isVisible()) {
+        return;
+    }
+
     QPainter painter(this);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
 
@@ -264,6 +278,7 @@ void CommonIconButton::mousePressEvent(QMouseEvent *event)
 
 void CommonIconButton::mouseReleaseEvent(QMouseEvent *event)
 {
+    // 旋转期间不触发点击信号。
     if (m_clickable && rect().contains(m_pressPos) && rect().contains(event->pos()) && (!m_refreshTimer || !m_refreshTimer->isActive())) {
         Q_EMIT clicked();
         return;

--- a/src/private-lastore-tray/commoniconbutton.h
+++ b/src/private-lastore-tray/commoniconbutton.h
@@ -13,6 +13,7 @@
 #include <QPropertyAnimation>
 #include <QGraphicsOpacityEffect>
 
+// 托盘图标按钮，负责显示静态图标和更新动画。
 class CommonIconButton : public QWidget
 {
 public:
@@ -61,8 +62,11 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:
+    // 按当前状态重新加载图标资源。
     void refreshIcon();
+    // 按主题和激活状态更新图标颜色。
     void updatePalette();
+    // 在两张动画帧之间切换透明度。
     void switchIcon();
 
 private:

--- a/src/private-lastore-tray/pluginproxyinterface.h
+++ b/src/private-lastore-tray/pluginproxyinterface.h
@@ -13,37 +13,16 @@ class PluginsItemInterface;
 class PluginProxyInterface
 {
 public:
-    ///
-    /// \brief itemAdded
-    /// add a new dock item
-    /// if itemkey of this plugin inter already exist, the new item
-    /// will be ignored, so if you need to add multiple item, you need
-    /// to ensure all itemKey is different.
-    /// \param itemInter
-    /// your plugin interface
-    /// \param itemKey
-    /// your item unique key
-    ///
+    // 向 dock 添加条目。
     virtual void itemAdded(PluginsItemInterface * const itemInter, const QString &itemKey) = 0;
-    ///
-    /// \brief itemUpdate
-    /// update(repaint) spec item
-    /// \param itemInter
-    /// \param itemKey
-    ///
+
+    // 通知 dock 刷新条目。
     virtual void itemUpdate(PluginsItemInterface * const itemInter, const QString &itemKey) = 0;
-    ///
-    /// \brief itemRemoved
-    /// remove spec item, if spec item is not exist, dock will to nothing.
-    /// dock will NOT delete your object, you should manage memory by your self.
-    /// \param itemInter
-    /// \param itemKey
-    ///
+
+    // 从 dock 移除条目。
     virtual void itemRemoved(PluginsItemInterface * const itemInter, const QString &itemKey) = 0;
-    ///
-    /// \brief requestContextMenu
-    /// request show context menu
-    ///
+
+    // 请求显示条目上下文菜单。
     //virtual void requestContextMenu(PluginsItemInterface * const itemInter, const QString &itemKey) = 0;
 
     virtual void requestWindowAutoHide(PluginsItemInterface * const itemInter, const QString &itemKey, const bool autoHide) = 0;
@@ -51,30 +30,13 @@ public:
 
     virtual void requestSetAppletVisible(PluginsItemInterface * const itemInter, const QString &itemKey, const bool visible) = 0;
 
-    ///
-    /// \brief saveValue
-    /// save module config to .config/deepin/dde-dock.conf
-    /// all key-values of all plugins will be save to that file
-    /// and grouped by the returned value of pluginName() function which is defined in PluginsItemInterface
-    /// \param itemInter the plugin object
-    /// \param key the key of data
-    /// \param value the data
-    ///
+    // 保存插件配置。
     virtual void saveValue(PluginsItemInterface * const itemInter, const QString &key, const QVariant &value) = 0;
 
-    ///
-    /// \brief getValue
-    /// SeeAlse: saveValue
-    /// return value from .config/deepin/dde-dock.conf
-    ///
+    // 读取插件配置。
     virtual const QVariant getValue(PluginsItemInterface *const itemInter, const QString &key, const QVariant& fallback = QVariant()) = 0;
 
-    ///
-    /// \brief removeValue
-    /// remove the values specified by keyList
-    /// remove all values of itemInter if keyList is empty
-    /// SeeAlse: saveValue
-    ///
+    // 删除插件配置。
     virtual void removeValue(PluginsItemInterface *const itemInter, const QStringList &keyList) = 0;
 };
 

--- a/src/private-lastore-tray/pluginsiteminterface.h
+++ b/src/private-lastore-tray/pluginsiteminterface.h
@@ -10,11 +10,7 @@
 #include <QIcon>
 #include <QtCore>
 
-///
-/// \brief The PluginsItemInterface class
-/// the dock plugins item interface, all dock plugins should
-/// inheirt this class and override all pure virtual function.
-///
+// Dock 插件条目接口，定义条目显示和交互能力。
 class PluginsItemInterface
 {
 public:
@@ -23,217 +19,92 @@ public:
         Fixed
     };
 
-    /**
-    * @brief Plugin size policy
-    */
+    // 条目尺寸跟随系统或使用自定义策略。
     enum PluginSizePolicy {
-        System = 1 << 0, // Follow the system
-        Custom = 1 << 1  // The custom
+        System = 1 << 0,
+        Custom = 1 << 1
     };
 
-    ///
-    /// \brief ~PluginsItemInterface
-    /// DON'T try to delete m_proxyInter.
-    ///
+    // 销毁插件条目对象。
     virtual ~PluginsItemInterface() {}
 
-    ///
-    /// \brief pluginName
-    /// tell dock the unique plugin id
-    /// \return
-    ///
+    // 返回插件唯一标识。
     virtual const QString pluginName() const = 0;
     virtual const QString pluginDisplayName() const { return QString(); }
 
-    ///
-    /// \brief init
-    /// init your plugins, you need to save proxyInter to m_proxyInter
-    /// member variable. but you shouldn't free this pointer.
-    /// \param proxyInter
-    /// DON'T try to delete this pointer.
-    ///
+    // 初始化条目并接收 dock 代理接口。
     virtual void init(PluginProxyInterface *proxyInter) = 0;
-    ///
-    /// \brief itemWidget
-    /// your plugin item widget, each item should have a unique key.
-    /// \param itemKey
-    /// your widget' unique key.
-    /// \return
-    ///
+
+    // 返回条目控件。
     virtual QWidget *itemWidget(const QString &itemKey) = 0;
 
-    ///
-    /// \brief itemTipsWidget
-    /// override this function if your item want to have a tips.
-    /// the tips will shown when user hover your item.
-    /// nullptr will be ignored.
-    /// \param itemKey
-    /// \return
-    ///
+    // 返回条目悬浮提示控件。
     virtual QWidget *itemTipsWidget(const QString &itemKey) {Q_UNUSED(itemKey); return nullptr;}
-    ///
-    /// \brief itemPopupApplet
-    /// override this function if your item wants to have an popup applet.
-    /// the popup applet will shown when user click your item.
-    ///
-    /// Tips:
-    /// dock should receive mouse press/release event to check user mouse operate,
-    /// if your item filter mouse event, this function will not be called.
-    /// so if you override mouse event and want to use popup applet, you
-    /// should pass event to your parent use QWidget::someEvent(e);
-    /// \param itemKey
-    /// \return
-    ///
+
+    // 返回条目点击后弹出的内容控件。
     virtual QWidget *itemPopupApplet(const QString &itemKey) {Q_UNUSED(itemKey); return nullptr;}
-    ///
-    /// \brief itemCommand
-    /// execute spec command when user clicked your item.
-    /// ensure your command do not get user input.
-    ///
-    /// empty string will be ignored.
-    /// \param itemKey
-    /// \return
-    ///
+
+    // 返回点击条目时执行的命令。
     virtual const QString itemCommand(const QString &itemKey) {Q_UNUSED(itemKey); return QString();}
 
-    ///
-    /// \brief itemContextMenu
-    /// context menu is shown when RequestPopupMenu called.
-    /// \param itemKey
-    /// \return
-    ///
+    // 返回条目上下文菜单定义。
     virtual const QString itemContextMenu(const QString &itemKey) {Q_UNUSED(itemKey); return QString();}
-    ///
-    /// \brief invokedMenuItem
-    /// call if context menu item is clicked
-    /// \param itemKey
-    /// \param itemId
-    /// menu item id
-    /// \param checked
-    ///
+
+    // 处理上下文菜单点击事件。
     virtual void invokedMenuItem(const QString &itemKey, const QString &menuId, const bool checked) {Q_UNUSED(itemKey); Q_UNUSED(menuId); Q_UNUSED(checked);}
 
-    ///
-    /// \brief itemSortKey
-    /// tell dock where your item wants to put on.
-    ///
-    /// this index is start from 1 and
-    /// 0 for left side
-    /// -1 for right side
-    /// \param itemKey
-    /// \return
-    ///
+    // 返回条目排序位置。
     virtual int itemSortKey(const QString &itemKey) {Q_UNUSED(itemKey); return 1;}
-    ///
-    /// \brief setSortKey
-    /// save your item new position
-    /// sort key will be changed when plugins order
-    /// changed(by user drag-drop)
-    /// \param itemKey
-    /// \param order
-    ///
+
+    // 保存条目排序位置。
     virtual void setSortKey(const QString &itemKey, const int order) {Q_UNUSED(itemKey); Q_UNUSED(order);}
 
-    ///
-    /// \brief itemAllowContainer
-    /// tell dock is your item allow to move into container
-    ///
-    /// if your item placed into container, popup tips and popup
-    /// applet will be disabled.
-    /// \param itemKey
-    /// \return
-    ///
+    // 返回条目是否允许进入容器区域。
     virtual bool itemAllowContainer(const QString &itemKey) {Q_UNUSED(itemKey); return false;}
-    ///
-    /// \brief itemIsInContainer
-    /// tell dock your item is in container, this function
-    /// called at item init and if your item enable container.
-    /// \param itemKey
-    /// \return
-    ///
+
+    // 返回条目当前是否在容器中。
     virtual bool itemIsInContainer(const QString &itemKey) {Q_UNUSED(itemKey); return false;}
-    ///
-    /// \brief setItemIsInContainer
-    /// save your item new state.
-    /// this function called when user drag out your item from
-    /// container or user drop item into container(if your item
-    /// allow drop into container).
-    /// \param itemKey
-    /// \param container
-    ///
+
+    // 保存条目容器状态。
     virtual void setItemIsInContainer(const QString &itemKey, const bool container) {Q_UNUSED(itemKey); Q_UNUSED(container);}
 
     virtual bool pluginIsAllowDisable() { return false; }
     virtual bool pluginIsDisable() { return false; }
     virtual void pluginStateSwitched() {}
 
-    ///
-    /// \brief displayModeChanged
-    /// override this function to receive display mode changed signal
-    /// \param displayMode
-    ///
+    // 处理 dock 显示模式变化。
     virtual void displayModeChanged(const Dock::DisplayMode displayMode) {Q_UNUSED(displayMode);}
-    ///
-    /// \brief positionChanged
-    /// override this function to receive dock position changed signal
-    /// \param position
-    ///
+
+    // 处理 dock 停靠位置变化。
     virtual void positionChanged(const Dock::Position position) {Q_UNUSED(position);}
 
-    ///
-    /// \brief refreshIcon
-    /// refresh item icon, its triggered when system icon theme changed.
-    /// \param itemKey
-    /// item key
-    ///
+    // 刷新条目图标。
     virtual void refreshIcon(const QString &itemKey) { Q_UNUSED(itemKey); }
 
-    ///
-    /// \brief displayMode
-    /// get current dock display mode
-    /// \return
-    ///
+    // 返回当前 dock 显示模式。
     inline Dock::DisplayMode displayMode() const
     {
         return qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>();
     }
 
-    ///
-    /// \brief position
-    /// get current dock position
-    /// \return
-    ///
+    // 返回当前 dock 停靠位置。
     inline Dock::Position position() const
     {
         return qApp->property(PROP_POSITION).value<Dock::Position>();
     }
 
-    ///
-    /// \brief settingsChanged
-    /// override this function to receive plugin settings changed signal(DeepinSync)
-    ///
+    // 处理插件设置变化。
     virtual void pluginSettingsChanged() {}
 
-    ///
-    /// \brief type
-    /// Default plugin add dock right, fixed plugin add to dock fixed area
-    ///
-    /// This function is deprecated, please use `flags()` instead of it
-    ///
+    // 返回插件类型。
     QT_DEPRECATED_X("Use flags()")
     virtual PluginType type() { return Normal; }
 
-    ///
-    /// \brief plugin size policy
-    /// default plugin size policy
-    ///
+    // 返回条目尺寸策略。
     virtual PluginSizePolicy pluginSizePolicy() const { return System; }
 
 protected:
-    ///
-    /// \brief m_proxyInter
-    /// NEVER delete this object.
-    ///
+    // 保存 dock 代理接口。
     PluginProxyInterface *m_proxyInter = nullptr;
 };
 

--- a/src/private-lastore-tray/privatelastoreitem.cpp
+++ b/src/private-lastore-tray/privatelastoreitem.cpp
@@ -7,19 +7,11 @@
 #include "tipswidget.h"
 
 #include <DDBusSender>
-#include <DGuiApplicationHelper>
-#include <DIconTheme>
 
 #include <QDBusConnection>
-#include <QDBusReply>
 #include <QIcon>
-#include <QJsonDocument>
-#include <QPainter>
-#include <QPaintEvent>
 #include <QVBoxLayout>
 #include <QMouseEvent>
-
-DGUI_USE_NAMESPACE
 
 PrivateLastoreItem::PrivateLastoreItem(QWidget* parent)
     : QWidget(parent)
@@ -49,19 +41,20 @@ QWidget* PrivateLastoreItem::tipsWidget()
 
 void PrivateLastoreItem::onRefreshIcon(const QList<QDBusObjectPath> &jobs)
 {
-    qInfo() << "Job list changed";
+    qInfo() << "Update job list changed";
 
     for (const auto &job : jobs) {
         const QString &jobPath = job.path();
-        qInfo() << "Path : " << jobPath;
+        qInfo() << "Update job path:" << jobPath;
         UpdateJobDBusProxy jobInter(jobPath, this);
         if (!jobInter.isValid()) {
-            qWarning() << "Job is invalid";
+            qWarning() << "Invalid update job";
             continue;
         }
 
         const QString &id = jobInter.id();
-        qInfo() << "Job id : " << id;
+        qInfo() << "Update job id:" << id;
+        // 下载或安装任务存在时显示更新动画。
         if (id == "dist_upgrade" || id == "prepare_dist_upgrade") {
             m_icon->startAnimation();
             return;
@@ -72,6 +65,9 @@ void PrivateLastoreItem::onRefreshIcon(const QList<QDBusObjectPath> &jobs)
 
 void PrivateLastoreItem::onStartAnimation(const QString &updateStatus)
 {
+    Q_UNUSED(updateStatus)
+
+    // 从更新状态中提取 system_upgrade 状态控制动画。
     QString systemUpgradeStatus = checkHasSystemUpdate(m_managerInter->updateStatus());
     if (systemUpgradeStatus == UPDATE_STATUS_UpdatesAvailable || systemUpgradeStatus == UPDATE_STATUS_Downloading ||
         systemUpgradeStatus == UPDATE_STATUS_DownloadPaused || systemUpgradeStatus == UPDATE_STATUS_UpgradeReady
@@ -85,6 +81,7 @@ void PrivateLastoreItem::resizeEvent(QResizeEvent* e)
 {
     QWidget::resizeEvent(e);
 
+    // 按 dock 停靠方向将条目约束为正方形区域。
     const Dock::Position position = qApp->property(PROP_POSITION).value<Dock::Position>();
     if (position == Dock::Bottom || position == Dock::Top) {
         setMaximumWidth(height());
@@ -95,8 +92,10 @@ void PrivateLastoreItem::resizeEvent(QResizeEvent* e)
     }
 }
 
-void PrivateLastoreItem::mouseReleaseEvent(QMouseEvent *event) {
+void PrivateLastoreItem::mouseReleaseEvent(QMouseEvent *event)
+{
     if (event->button() == Qt::LeftButton && m_controlCenterInterface) {
+        // 左键点击后打开控制中心更新模块。
         DDBusSender()
             .service("org.deepin.dde.ControlCenter1")
             .interface("org.deepin.dde.ControlCenter1")
@@ -107,4 +106,3 @@ void PrivateLastoreItem::mouseReleaseEvent(QMouseEvent *event) {
     }
     QWidget::mouseReleaseEvent(event);
 }
-

--- a/src/private-lastore-tray/privatelastoreitem.h
+++ b/src/private-lastore-tray/privatelastoreitem.h
@@ -17,7 +17,7 @@ namespace Dock {
 class TipsWidget;
 }
 
-class AirplaneModeApplet;
+// 托盘条目，负责图标显示和点击跳转。
 class PrivateLastoreItem : public QWidget
 {
     Q_OBJECT

--- a/src/private-lastore-tray/privatelastoreplugin.cpp
+++ b/src/private-lastore-tray/privatelastoreplugin.cpp
@@ -8,13 +8,11 @@
 #include "common/global_util/public_func.h"
 
 #include <DStandardPaths>
-#include <DGuiApplicationHelper>
 
 #define PRIVATE_LASTORE_KEY "private-lastore-key"
 #define STATE_KEY "enabled"
 
 DCORE_USE_NAMESPACE
-DGUI_USE_NAMESPACE
 Q_LOGGING_CATEGORY(dockPrivateUpdatePlugin, "org.deepin.dde.dock.update")
 
 PrivateLastorePlugin::PrivateLastorePlugin(QObject *parent)
@@ -22,7 +20,10 @@ PrivateLastorePlugin::PrivateLastorePlugin(QObject *parent)
     , m_item(new PrivateLastoreItem)
 {
     QTranslator *translator = new QTranslator(this);
-    translator->load(QLocale(), "private-lastore-tray", "_", "/usr/share/private-lastore-tray/translations");
+    const bool loaded = translator->load(QLocale(), "private-lastore-tray", "_", "/usr/share/private-lastore-tray/translations");
+    if (!loaded) {
+        qCWarning(dockPrivateUpdatePlugin) << "Failed to load private-lastore-tray translations";
+    }
     QCoreApplication::installTranslator(translator);
 }
 
@@ -32,12 +33,6 @@ PrivateLastorePlugin::~PrivateLastorePlugin()
         delete m_item;
         m_item = nullptr;
     }
-}
-
-void PrivateLastorePlugin::loadPlugin()
-{
-    m_proxyInter->itemAdded(this, PRIVATE_LASTORE_KEY);
-    displayModeChanged(displayMode());
 }
 
 const QString PrivateLastorePlugin::pluginName() const

--- a/src/private-lastore-tray/privatelastoreplugin.h
+++ b/src/private-lastore-tray/privatelastoreplugin.h
@@ -32,9 +32,6 @@ public:
     QWidget *itemTipsWidget(const QString &itemKey) Q_DECL_OVERRIDE;
 
 private:
-    void loadPlugin();
-
-private:
     PrivateLastoreItem *m_item;
 };
 

--- a/src/private-lastore-tray/tipswidget.cpp
+++ b/src/private-lastore-tray/tipswidget.cpp
@@ -8,14 +8,10 @@
 
 #include <QPainter>
 #include <QAccessible>
-#include <QFile>
-#include <QTextDocument>
 
 Q_LOGGING_CATEGORY(dockUpdatePlugin, "org.deepin.dde.dock.update")
 #define PADDING 4
 #define SHUTDOWNUPDATESTATUS 5
-static const int BACKUP_START_PROGRESS = 20;
-static const int BACKUP_SUCCESS_PROGRESS = 50;
 
 TipsWidget::TipsWidget(QWidget *parent)
     : QFrame(parent)
@@ -67,7 +63,7 @@ bool TipsWidget::checkShutdownUpdate()
     int lastoreStatus = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "","lastore-daemon-status", 0).toInt();
     if (lastoreStatus == SHUTDOWNUPDATESTATUS) {
         m_textList.append(tr("Download complete"));
-        m_textList.append(tr("shutdown update"));
+        m_textList.append(tr("Shutdown update"));
         return true;
     } else {
         return false;
@@ -87,30 +83,13 @@ bool TipsWidget::checkRegularlyUpdate()
         if (dateTime.isValid()) {
             QString formattedDateTime = dateTime.toString("HH:mm:ss");
             m_textList.append(tr("Download complete"));
-            QString info = tr("will upgrade at %1");
+            QString info = tr("Will upgrade at %1");
             m_textList.append(info.arg(formattedDateTime));
             return true;
         }
         return false;
     }
     return false;
-}
-
-void TipsWidget::onUpdatePropertiesChanged(const QString& interfaceName, const QVariantMap& changedProperties, const QStringList& invalidatedProperties)
-{
-    Q_UNUSED(invalidatedProperties)
-
-    if (interfaceName == "org.deepin.dde.Lastore1.Job") {
-        if (changedProperties.contains("Speed")) {
-            m_speed = changedProperties.value("Speed").toULongLong();
-        }
-
-        if (changedProperties.contains("Proto")) {
-            m_proto = changedProperties.value("Proto").toString();
-        }
-    }
-    refreshContent();
-    update();
 }
 
 void TipsWidget::onSetUpdateProgress(double progress)
@@ -131,59 +110,58 @@ void TipsWidget::refreshContent()
 {
     m_textList.clear();
     if (m_downloadLimitOnChanging) {
-        m_textList.append(tr("Is changing download speed limit. Please wait"));
+        m_textList.append(tr("Changing download speed limit. Please wait"));
         return;
     }
+
+    // 优先根据当前任务生成提示，没有任务时再根据总体状态生成提示。
     if (m_managerInter) {
         QList<QDBusObjectPath> jobList = m_managerInter->jobList();
         if (jobList.isEmpty()) {
-            //当前无任务，需检测是否为任务执行完成状态
-            //检查当前是否为关机更新状态
+            // 没有任务时优先显示下载完成后的后续状态。
             if (checkShutdownUpdate()) return;
-            //检查当前是否为定时更新状态
             if (checkRegularlyUpdate()) return;
-            //检查是否有可更新内容
             QString systemUpgradeStatus = checkHasSystemUpdate(m_managerInter->updateStatus());
             if (systemUpgradeStatus == UPDATE_STATUS_BackupFailed || systemUpgradeStatus == UPDATE_STATUS_UpgradeFailed) {
-                m_textList.append(tr("Upgrade failed.Please go to check."));
+                m_textList.append(tr("Upgrade failed. Please check."));
                 return;
             } else if (systemUpgradeStatus == UPDATE_STATUS_UpgradeSuccess) {
-                m_textList.append(tr("Upgrade conplete.Please reboot"));
+                m_textList.append(tr("Upgrade complete. Please reboot."));
                 return;
             } else if (systemUpgradeStatus == UPDATE_STATUS_Downloaded) {
-                m_textList.append(tr("Download complete.Please go to control-center to check."));
+                m_textList.append(tr("Download complete. Please open Control Center to check."));
             } else if (systemUpgradeStatus == UPDATE_STATUS_UpdatesAvailable || systemUpgradeStatus == UPDATE_STATUS_Downloading||
                 systemUpgradeStatus == UPDATE_STATUS_DownloadPaused || systemUpgradeStatus == UPDATE_STATUS_UpgradeReady
                 || systemUpgradeStatus == UPDATE_STATUS_Upgrading) {
-                m_textList.append(tr("Has new version.Please go to check."));
+                m_textList.append(tr("New version available. Please check."));
                 return;
             }
         } else {
             for (const auto &job : jobList) {
                 const QString &jobPath = job.path();
-                qInfo() << "Path : " << jobPath;
+                qInfo() << "Update job path:" << jobPath;
                 UpdateJobDBusProxy jobInter(jobPath, this);
                 if (!jobInter.isValid()) {
-                    qWarning() << "Job is invalid";
+                    qWarning() << "Invalid update job";
                     continue;
                 }
                 QString curJobStatus = jobInter.status();
                 QString curJobId = jobInter.id();
                 QString curStatus;
                 if (curJobStatus == "running" || curJobStatus == "ready") {
-                    //当前有任务在进行
+                    // 按任务类型生成当前提示内容。
                     if (curJobId == "backup" && m_backupJobInter) {
-                        QString curProgress = tr("current upgrade process");
-                        curStatus = tr("backing up");
+                        QString curProgress = tr("Current upgrade progress");
+                        curStatus = tr("Backing up");
                         m_textList.append(curStatus);
                         m_textList.append(QString("%1: %2%")
                             .arg(curProgress)
                             .arg(QString::number(qRound(m_backupProgress / 0.01))));
                     } else if (curJobId == "prepare_dist_upgrade" && m_updateJobInter) {
-                        //任务类型为下载任务，展示下载信息
-                        curStatus = tr("download");
-                        QString curProgress = tr("current download process");
-                        QString curSpeed = tr("current speed");
+                        // 下载阶段显示进度、速度和协议。
+                        curStatus = tr("Downloading");
+                        QString curProgress = tr("Current download progress");
+                        QString curSpeed = tr("Current speed");
                         m_textList.append(QString("%1, %2: %3%")
                                           .arg(curStatus)
                                           .arg(curProgress)
@@ -193,24 +171,24 @@ void TipsWidget::refreshContent()
                                 .arg(regulateSpeed())
                                 .arg(m_proto));
                     } else if (curJobId == "dist_upgrade" && m_updateJobInter) {
-                        //任务类型为更新任务，展示更新信息
-                        QString curProgress = tr("current upgrade process");
-                        curStatus = tr("install");
+                        // 安装阶段仅显示升级进度。
+                        QString curProgress = tr("Current upgrade progress");
+                        curStatus = tr("Installing");
                         m_textList.append(curStatus);
                         m_textList.append(QString("%1: %2%")
                                     .arg(curProgress)
                                     .arg(QString::number(qRound(m_updateProgress / 0.01))));
                     } else if (curJobId == "update_source" && m_updateJobInter) {
-                            QString systemUpgradeStatus = checkHasSystemUpdate(m_managerInter->updateStatus());
-                            if (systemUpgradeStatus == UPDATE_STATUS_UpdatesAvailable || systemUpgradeStatus == UPDATE_STATUS_Downloading||
-                                systemUpgradeStatus == UPDATE_STATUS_DownloadPaused || systemUpgradeStatus == UPDATE_STATUS_UpgradeReady
-                                || systemUpgradeStatus == UPDATE_STATUS_Upgrading || systemUpgradeStatus == UPDATE_STATUS_Downloaded) {
-                        // 由于每次打开控制中心都会触发检查更新，此时有可能已经是downloaded状态且也有job
-                            m_textList.append(tr("Has new version.Please go to check."));
+                        QString systemUpgradeStatus = checkHasSystemUpdate(m_managerInter->updateStatus());
+                        if (systemUpgradeStatus == UPDATE_STATUS_UpdatesAvailable || systemUpgradeStatus == UPDATE_STATUS_Downloading||
+                            systemUpgradeStatus == UPDATE_STATUS_DownloadPaused || systemUpgradeStatus == UPDATE_STATUS_UpgradeReady
+                            || systemUpgradeStatus == UPDATE_STATUS_Upgrading || systemUpgradeStatus == UPDATE_STATUS_Downloaded) {
+                            // 更新源检查任务存在时仍保持新版本提示。
+                            m_textList.append(tr("New version available. Please check."));
                         }
                     }
                 } else {
-                    //无running任务状态下没有监控任务状态的必要，展示标题文案，防止出现空白气泡
+                    // 非运行态任务不显示进度提示。
                     m_speed = 0.0;
                     if (m_textList.length() != 0)
                         m_textList.clear();
@@ -225,7 +203,7 @@ QString TipsWidget::regulateSpeed()
 {
     QString unitName;
     double regulatedProcess;
-    bool needDecimal = false; //是否需要保留一位小数
+    bool needDecimal = false; // 控制是否保留一位小数。
 
     if (m_speed >= 1024 * 1024) {
         regulatedProcess = static_cast<double>(m_speed) / (1024 * 1024);
@@ -243,19 +221,15 @@ QString TipsWidget::regulateSpeed()
     return QString("%1%2").arg(regulatedProcess, 0, 'f', needDecimal ? 1 : 0).arg(unitName);
 }
 
-void TipsWidget::onDownloadLimitChanged(bool value) {
-    m_downloadLimitOnChanging = value;
-}
-
 void TipsWidget::onRefreshJobList(const QList<QDBusObjectPath> &jobs)
 {
-    qInfo() << "Job list changed";
+    qInfo() << "Update job list changed";
 
     for (const auto &job : jobs) {
         const QString &jobPath = job.path();
         UpdateJobDBusProxy jobInter(jobPath, this);
 
-        //检测到有更新任务
+        // 记录任务代理并监听进度变化。
         const QString &id = jobInter.id();
         if (id == "dist_upgrade" || id == "prepare_dist_upgrade") {
             m_updateJobInter = new UpdateJobDBusProxy(jobPath, this);
@@ -266,16 +240,11 @@ void TipsWidget::onRefreshJobList(const QList<QDBusObjectPath> &jobs)
         }
     }
 }
-
-
-/**
- * @brief TipsWidget::paintEvent 任务栏插件提示信息绘制
- * @param event
- */
 void TipsWidget::paintEvent(QPaintEvent *event)
 {
     QFrame::paintEvent(event);
 
+    // 按当前文本内容绘制提示气泡。
     QPainter painter(this);
     painter.setPen(QPen(palette().brightText(), 1));
 
@@ -289,7 +258,7 @@ void TipsWidget::paintEvent(QPaintEvent *event)
         break;
     case MultiLine: {
         if (m_textList.size() == 0) {
-            m_textList.append(tr("Enterprise-level Upgrade Management System"));
+            m_textList.append(tr("Enterprise Upgrade Management System"));
         }
 
         int x = rect().x();

--- a/src/private-lastore-tray/tipswidget.h
+++ b/src/private-lastore-tray/tipswidget.h
@@ -27,6 +27,7 @@
 #define UPDATE_STATUS_UpgradeFailed "upgradeFailed"
 #define UPDATE_STATUS_UpgradeSuccess "needReboot"
 
+// 从更新状态 JSON 中提取 system_upgrade 字段。
 inline QString checkHasSystemUpdate(const QString& updateStatus)
 {
     QJsonParseError parseError;
@@ -45,6 +46,7 @@ inline QString checkHasSystemUpdate(const QString& updateStatus)
     return systemUpgradeStatus;
 }
 
+// 托盘提示气泡，按任务状态生成显示文案。
 class TipsWidget : public QFrame
 {
     Q_OBJECT
@@ -65,16 +67,15 @@ protected:
     bool event(QEvent *event) override;
 
 private:
+    // 判断是否处于关机更新状态。
     bool checkShutdownUpdate();
+    // 判断是否已设置定时升级。
     bool checkRegularlyUpdate();
+    // 将下载速度格式化为展示文本。
     QString regulateSpeed();
 
 private slots:
-    void onDownloadLimitChanged(bool value);
     void onRefreshJobList(const QList<QDBusObjectPath> &jobs);
-    void onUpdatePropertiesChanged(const QString& interfaceName,
-                                   const QVariantMap& changedProperties,
-                                   const QStringList& invalidatedProperties);
     void onSetUpdateProgress(double progress);
     void onSetBackUpProgress(double progress);
 

--- a/src/private-lastore-tray/translations/private-lastore-tray.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray.ts
@@ -19,72 +19,72 @@
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="62"/>
-        <source>shutdown update</source>
+        <source>Shutdown update</source>
         <translation>将在下次关机/重启时开始更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="100"/>
-        <source>will upgrade at %1</source>
+        <source>Will upgrade at %1</source>
         <translation>将于%1开始系统更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="141"/>
-        <source>Download complete.Please go to control-center to check.</source>
+        <source>Download complete. Please open Control Center to check.</source>
         <translation>更新包下载完成，点击图标进入更新界面进行查看与安装更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="136"/>
-        <source>Is changing download speed limit. Please wait</source>
+        <source>Changing download speed limit. Please wait</source>
         <translation>下载限速配置切换中，切换完成后将会继续下载更新资源</translation>
     </message>
     <message>
-        <source>Upgrade conplete.Please reboot</source>
+        <source>Upgrade complete. Please reboot.</source>
         <translation>更新完成,请重启系统</translation>
     </message>
     <message>
-        <source>Upgrade failed.Please go to check.</source>
+        <source>Upgrade failed. Please check.</source>
         <translation>更新失败,点击查看</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="145"/>
         <location filename="../tipswidget.cpp" line="205"/>
-        <source>Has new version.Please go to check.</source>
+        <source>New version available. Please check.</source>
         <translation>有新版本，点击图标查看</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="161"/>
         <location filename="../tipswidget.cpp" line="185"/>
-        <source>current upgrade process</source>
+        <source>Current upgrade progress</source>
         <translation>更新进度</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="163"/>
-        <source>backing up</source>
+        <source>Backing up</source>
         <translation>备份中</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="173"/>
-        <source>download</source>
+        <source>Downloading</source>
         <translation>更新包下载中</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="174"/>
-        <source>current download process</source>
+        <source>Current download progress</source>
         <translation>已下载</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="175"/>
-        <source>current speed</source>
+        <source>Current speed</source>
         <translation>下载速度</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="186"/>
-        <source>install</source>
+        <source>Installing</source>
         <translation>系统更新中,请勿关闭计算机</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="292"/>
-        <source>Enterprise-level Upgrade Management System</source>
+        <source>Enterprise Upgrade Management System</source>
         <translation>企业级更新管理系统</translation>
     </message>
 </context>

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_CN.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_CN.ts
@@ -19,72 +19,72 @@
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="62"/>
-        <source>shutdown update</source>
+        <source>Shutdown update</source>
         <translation>将在下次关机/重启时开始更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="100"/>
-        <source>will upgrade at %1</source>
+        <source>Will upgrade at %1</source>
         <translation>将于%1开始系统更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="141"/>
-        <source>Download complete.Please go to control-center to check.</source>
+        <source>Download complete. Please open Control Center to check.</source>
         <translation>更新包下载完成，点击图标进入更新界面进行查看与安装更新</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="136"/>
-        <source>Is changing download speed limit. Please wait</source>
+        <source>Changing download speed limit. Please wait</source>
         <translation>下载限速配置切换中，切换完成后将会继续下载更新资源</translation>
     </message>
     <message>
-        <source>Upgrade conplete.Please reboot</source>
+        <source>Upgrade complete. Please reboot.</source>
         <translation>更新完成,请重启系统</translation>
     </message>
     <message>
-        <source>Upgrade failed.Please go to check.</source>
+        <source>Upgrade failed. Please check.</source>
         <translation>更新失败,点击查看</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="145"/>
         <location filename="../tipswidget.cpp" line="205"/>
-        <source>Has new version.Please go to check.</source>
+        <source>New version available. Please check.</source>
         <translation>有新版本，点击图标查看</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="161"/>
         <location filename="../tipswidget.cpp" line="185"/>
-        <source>current upgrade process</source>
+        <source>Current upgrade progress</source>
         <translation>更新进度</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="163"/>
-        <source>backing up</source>
+        <source>Backing up</source>
         <translation>备份中</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="173"/>
-        <source>download</source>
+        <source>Downloading</source>
         <translation>更新包下载中</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="174"/>
-        <source>current download process</source>
+        <source>Current download progress</source>
         <translation>已下载</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="175"/>
-        <source>current speed</source>
+        <source>Current speed</source>
         <translation>下载速度</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="186"/>
-        <source>install</source>
+        <source>Installing</source>
         <translation>系统更新中,请勿关闭计算机</translation>
     </message>
     <message>
         <location filename="../tipswidget.cpp" line="292"/>
-        <source>Enterprise-level Upgrade Management System</source>
+        <source>Enterprise Upgrade Management System</source>
         <translation>企业级更新管理系统</translation>
     </message>
 </context>


### PR DESCRIPTION
Standardize comments in private-lastore-tray, clean up unused code and includes, and fix warnings exposed during the refactor

Log: Clean up code structure and eliminate compile warnings
Task: https://pms.uniontech.com/task-view-387713.html
Influence: No functional changes, only affects code readability and build cleanliness

chore: V25版本私有化更新-注释与代码整理

统一 private-lastore-tray 目录下注释风格，清理无用代码与无效引用，
并修复整理过程中暴露的编译告警问题

Log: 规范注释与日志文案，清理未使用代码，消除编译告警
Task: https://pms.uniontech.com/task-view-387713.html
Influence: 不涉及功能变更，仅影响代码可读性与编译洁净度