### PR TITLE
fix: correct tray and control center copy issues

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -304,6 +304,9 @@ void UpdateWorker::initConfig()
                     m_model->setLastoreDaemonStatus(value);
                 }
             }
+            if ("update-time" == key) {
+                m_model->setScheduledUpgradeTime();
+            }
         });
     } else {
         qCWarning(logDccUpdatePlugin) << "Lastore dconfig is nullptr or invalid";

--- a/src/dcc-update-plugin/qml/UpdateMain.qml
+++ b/src/dcc-update-plugin/qml/UpdateMain.qml
@@ -289,21 +289,26 @@ DccObject {
         pageType: DccObject.Item
 
         page: UpdateControl {
+            id: preInstallUpdateControl
             updateListModels: dccData.model().preInstallListModel
             updateTitle: qsTr("Update download completed")
             btnActions: dccData.model().isPrivateUpdate ? [ 
                 qsTr("Install Now"),
                 qsTr("Check Again")
             ] : [qsTr("Install updates")]
+            function updateSecondaryTips() {
+                secondaryUpdateTips = dccData.model().scheduledUpgradeTime.length !== 0
+                    ? qsTr("will upgrade at %1").arg(dccData.model().scheduledUpgradeTime)
+                    : ""
+            }
             updateTips: {
                 if (!dccData.model().batterIsOK) {
                     return qsTr("The battery capacity is lower than 60%. To get successful updates, please plug in.")
                 }
                 return qsTr("Update size: ") + dccData.model().preInstallListModel.downloadSize
             }
-            secondaryUpdateTips: dccData.model().scheduledUpgradeTime.length !== 0
-                ? qsTr("will upgrade at %1").arg(dccData.model().scheduledUpgradeTime)
-                : ""
+            secondaryUpdateTips: ""
+            Component.onCompleted: updateSecondaryTips()
             busyState: dccData.model().upgradeWaiting
             updateListEnable: !dccData.model().upgradeWaiting
 
@@ -333,6 +338,13 @@ DccObject {
                 }
                 onUpgradeShutdownBtnClicked: {
                     dccData.work().modalUpgrade(false)
+                }
+            }
+
+            Connections {
+                target: dccData.model()
+                function onScheduledUpgradeTimeChanged() {
+                    preInstallUpdateControl.updateSecondaryTips()
                 }
             }
 

--- a/src/private-lastore-tray/tipswidget.cpp
+++ b/src/private-lastore-tray/tipswidget.cpp
@@ -92,6 +92,30 @@ bool TipsWidget::checkRegularlyUpdate()
     return false;
 }
 
+bool TipsWidget::hasUnfinishedJob(const QList<QDBusObjectPath> &jobs) const
+{
+    for (const auto &job : jobs) {
+        UpdateJobDBusProxy jobInter(job.path());
+        if (!jobInter.isValid()) {
+            continue;
+        }
+
+        QString curJobId = jobInter.id();
+        if (curJobId != "prepare_dist_upgrade"
+                && curJobId != "dist_upgrade"
+                && curJobId != "update_source") {
+            continue;
+        }
+
+        const QString status = jobInter.status();
+        if (status != "failed" && status != "end") {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void TipsWidget::onSetUpdateProgress(double progress)
 {
     m_updateProgress = progress;
@@ -117,7 +141,7 @@ void TipsWidget::refreshContent()
     // 优先根据当前任务生成提示，没有任务时再根据总体状态生成提示。
     if (m_managerInter) {
         QList<QDBusObjectPath> jobList = m_managerInter->jobList();
-        if (jobList.isEmpty()) {
+        if (jobList.isEmpty() || !hasUnfinishedJob(jobList)) {
             // 没有任务时优先显示下载完成后的后续状态。
             if (checkShutdownUpdate()) return;
             if (checkRegularlyUpdate()) return;
@@ -188,10 +212,7 @@ void TipsWidget::refreshContent()
                         }
                     }
                 } else {
-                    // 非运行态任务不显示进度提示。
-                    m_speed = 0.0;
-                    if (m_textList.length() != 0)
-                        m_textList.clear();
+                    // 非 failed/end 且暂不展示进度的任务先跳过。
                     continue;
                 }
             }

--- a/src/private-lastore-tray/tipswidget.h
+++ b/src/private-lastore-tray/tipswidget.h
@@ -71,6 +71,8 @@ private:
     bool checkShutdownUpdate();
     // 判断是否已设置定时升级。
     bool checkRegularlyUpdate();
+    // 判断任务列表中是否仍有未进入 failed/end 的任务。
+    bool hasUnfinishedJob(const QList<QDBusObjectPath> &jobs) const;
     // 将下载速度格式化为展示文本。
     QString regulateSpeed();
 


### PR DESCRIPTION
1. Fix incorrect tray copy caused by failed tasks not being cleared in download and update failure scenarios.
2. Fix the issue where the control center cannot dynamically refresh its copy after a scheduled update is fetched and the download is completed.

Log: As described above
Bug: https://pms.uniontech.com/bug-view-355929.html https://pms.uniontech.com/bug-view-354735.html
Influence: Affects the copy shown in the scheduled update control center and the tray copy when tasks fail.

fix: 修复托盘和控制中心的文案问题

1.修复在下载和更新失败的场景下因为failed任务未清除导致的托盘文案错误问题
2.修复获取定时更新后下载完成时控制中心无法动态刷新文案的问题

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-355929.html https://pms.uniontech.com/bug-view-354735.html
Influence：影响定时更新控制中心的文案和任务失败时托盘的文案