### PR TITLE
fix: 私有化更新-前端第三轮bug修复

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -209,12 +209,13 @@ QString UpdateDBusProxy::updateStatus()
 
 bool UpdateDBusProxy::p2PUpdateEnable()
 {
-    return qvariant_cast<bool>(m_managerInter->property("P2PUpdateEnable"));
+    return qvariant_cast<bool>(m_updateInter->property("P2PUpdateEnable"));
 }
 
 bool UpdateDBusProxy::p2PUpdateSupport()
 {
-    return qvariant_cast<bool>(m_managerInter->property("P2PUpdateSupport"));
+    return true;
+    // return qvariant_cast<bool>(m_updateInter->property("P2PUpdateSupport"));
 }
 
 bool UpdateDBusProxy::immutableAutoRecovery()

--- a/src/common/dbus/updatejobdbusproxy.cpp
+++ b/src/common/dbus/updatejobdbusproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "updatejobdbusproxy.h"
@@ -102,4 +102,9 @@ QString UpdateJobDBusProxy::status()
 QString UpdateJobDBusProxy::type()
 {
     return qvariant_cast<QString>(m_updateJobInter->property("Type"));
+}
+
+QString UpdateJobDBusProxy::proto()
+{
+    return qvariant_cast<QString>(m_updateJobInter->property("Proto"));
 }

--- a/src/common/dbus/updatejobdbusproxy.h
+++ b/src/common/dbus/updatejobdbusproxy.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018-2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef UPDATEJOBDBUSPROXY_H
@@ -56,6 +56,9 @@ public:
     Q_PROPERTY(QString Type READ type NOTIFY TypeChanged)
     QString type();
 
+    Q_PROPERTY(QString Proto READ proto NOTIFY ProtoChanged)
+    QString proto();
+
     inline QString path() const { return m_path; };
 
 signals:
@@ -73,6 +76,7 @@ signals:
     void SpeedChanged(qlonglong  value) const;
     void StatusChanged(const QString & value) const;
     void TypeChanged(const QString & value) const;
+    void ProtoChanged(const QString & value) const;
 
 private:
     DDBusInterface *m_updateJobInter;

--- a/src/dcc-update-plugin/operation/updatedatastructs.h
+++ b/src/dcc-update-plugin/operation/updatedatastructs.h
@@ -185,6 +185,7 @@ struct UpgradeSpeedLimitConfig {
 
     static UpgradeSpeedLimitConfig fromJson(const QByteArray& configStr)
     {
+        qWarning() << "xiongbo123 fromJson: " << configStr;
         UpgradeSpeedLimitConfig config;
         QJsonParseError jsonParseError;
         const QJsonDocument doc = QJsonDocument::fromJson(configStr, &jsonParseError);

--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -6,9 +6,11 @@
 #include "updatemodel.h"
 #include "updatehistorymodel.h"
 #include "operation/common.h"
+#include "common/common/dconfig_helper.h"
 #include "utils.h"
 
 #include <DSysInfo>
+#include <QDateTime>
 #include <QLoggingCategory>
 
 using namespace dcc::update::common;
@@ -16,6 +18,7 @@ using namespace dcc::update::common;
 Q_DECLARE_LOGGING_CATEGORY(logDccUpdatePlugin)
 
 DCORE_USE_NAMESPACE
+static constexpr int ShutdownUpdateStatus = 5;
 static const QMap<UpdatesStatus, ControlPanelType> ControlPanelTypeMapping = {
     { Default, CPT_Invalid },
     { UpdatesAvailable, CPT_Available },
@@ -90,6 +93,7 @@ UpdateModel::UpdateModel(QObject* parent)
     , m_showVersion("")
     , m_baseline("")
     , m_p2pUpdateEnabled(false)
+    , m_forceUpdate(false)
     , m_historyModel(new UpdateHistoryModel(this))
 {
     qCDebug(logDccUpdatePlugin) << "Initialize UpdateModel";
@@ -1175,73 +1179,80 @@ void UpdateModel::setSpeedLimitConfig(const QByteArray& config)
     Q_EMIT downloadSpeedLimitConfigChanged();
 }
 
-void UpdateModel::setUpgradeDownloadSpeedLimitConfig(const QByteArray& config)
+void UpdateModel::setUpgradeDownloadSpeedLimitConfig(const QByteArray& config, bool needEmitSignal)
 {
-    qCInfo(logDccUpdatePlugin) << "setUpgradeDownloadSpeedLimitConfig" << config;
-    // if (m_upgradeDownloadSpeedLimitConfig == config)
-    //     return;
-
+    qCInfo(logDccUpdatePlugin) << "Set upgrade download speed limit  config" << config;
     m_upgradeDownloadSpeedLimitConfig = config;
-    Q_EMIT upgradeDownloadSpeedLimitConfigChanged();
+    if (needEmitSignal)
+        Q_EMIT upgradeDownloadSpeedLimitConfigChanged();
 }
 
 QString UpdateModel::upgradeDownloadSpeedCurrentRate() const
 {
-    qCInfo(logDccUpdatePlugin) << "upgradeDownloadSpeedCurrentRate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).currentRate;
-    return QString::number(UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).currentRate / 1024);
+    qCInfo(logDccUpdatePlugin) << "Upgrade download speed current rate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).currentRate;
+    return QString::number(LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).limitSpeed.toInt() / 1024);
 }
 
 QString UpdateModel::upgradeDownloadSpeedLimitRate() const
 {
-    qCInfo(logDccUpdatePlugin) << "upgradeDownloadSpeedCurrentRate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).currentRate;
-    return QString::number(UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).limitRate / 1024);
+    qCInfo(logDccUpdatePlugin) << "Upgrade download speed limit rate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).limitRate;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).limitSpeed;
 }
 
 bool UpdateModel::upgradeDownloadSpeedEnable() const
 {
-    qCInfo(logDccUpdatePlugin) << "upgradeDownloadSpeedCurrentRate " << m_upgradeDownloadSpeedLimitConfig;
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).shouldLimitRate();
+    qCInfo(logDccUpdatePlugin) << "Upgrade download speed enable " << m_upgradeDownloadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).speedLimitEnabled;
 }
 
 bool UpdateModel::upgradeDownloadSpeedIsOnline() const
 {
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).ifInOnlineLimit();
+    qCInfo(logDccUpdatePlugin) << "Upgrade download speed is online " << m_upgradeDownloadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig).isOnlineSpeedLimit;
 }
 
-UpgradeSpeedLimitConfig UpdateModel::upgradeDownloadSpeedLimitConfig() const
+LastoreUpgradeSpeedLimitConfig UpdateModel::upgradeDownloadSpeedLimitConfig() const
 {
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig);
+    qCInfo(logDccUpdatePlugin) << "Upgrade download speed limit config " << m_upgradeDownloadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeDownloadSpeedLimitConfig);
 }
 
-void UpdateModel::setUpgradeUploadSpeedLimitConfig(const QByteArray& config)
+void UpdateModel::setUpgradeUploadSpeedLimitConfig(const QByteArray& config, bool needEmitSignal)
 {
+    qCInfo(logDccUpdatePlugin) << "Set upgrade upload speed limit config" << config;
     m_upgradeUploadSpeedLimitConfig = config;
-    Q_EMIT upgradeUploadSpeedLimitConfigChanged();
+    if (needEmitSignal)
+        Q_EMIT upgradeUploadSpeedLimitConfigChanged();
 }
 
 QString UpdateModel::upgradeUploadSpeedCurrentRate() const
 {
-    return QString::number(UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).currentRate / 1024);
+    qCInfo(logDccUpdatePlugin) << "Upgrade upload speed current rate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).currentRate;
+    return QString::number(LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).limitSpeed.toInt() / 1024);
 }
 
 QString UpdateModel::upgradeUploadSpeedLimitRate() const
 {
-    return QString::number(UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).limitRate / 1024);
+     qCInfo(logDccUpdatePlugin) << "Upgrade upload speed limit rate " << UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).limitRate;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).limitSpeed;
 }
 
 bool UpdateModel::upgradeUploadSpeedEnable() const
 {
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).shouldLimitRate();
+    qCInfo(logDccUpdatePlugin) << "Upgrade upload speed enable " << m_upgradeDownloadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).speedLimitEnabled;
 }
 
 bool UpdateModel::upgradeUploadSpeedIsOnline() const
 {
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).ifInOnlineLimit();
+    qCInfo(logDccUpdatePlugin) << "Upgrade upload speed is online " << m_upgradeDownloadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig).isOnlineSpeedLimit;
 }
 
-UpgradeSpeedLimitConfig UpdateModel::upgradeUploadSpeedLimitConfig() const
+LastoreUpgradeSpeedLimitConfig UpdateModel::upgradeUploadSpeedLimitConfig() const
 {
-    return UpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig);
+    qCInfo(logDccUpdatePlugin) << "Upgrade upload speed limit config " << m_upgradeUploadSpeedLimitConfig;
+    return LastoreUpgradeSpeedLimitConfig::fromJson(m_upgradeUploadSpeedLimitConfig);
 }
 
 bool UpdateModel::upgradeDeliveryEnable() const
@@ -1449,6 +1460,29 @@ void UpdateModel::setP2PUpdateEnabled(bool enabled)
         m_p2pUpdateEnabled = enabled;
         Q_EMIT p2pUpdateEnableStateChanged(enabled);
     }
+}
+
+void UpdateModel::setForceUpdate()
+{
+    bool forceUpdate = false;
+    const int lastoreStatus = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "", "lastore-daemon-status", 0).toInt();
+
+    if (lastoreStatus == ShutdownUpdateStatus) {
+        forceUpdate = true;
+    } else {
+        const QString updateTime = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "", "update-time", "").toString();
+        if (!updateTime.isEmpty()) {
+            forceUpdate = QDateTime::fromString(updateTime, Qt::ISODate).isValid();
+        }
+    }
+
+    qCDebug(logDccUpdatePlugin) << "Set force update:" << forceUpdate << "old value:" << m_forceUpdate;
+    if (m_forceUpdate == forceUpdate) {
+        return;
+    }
+
+    m_forceUpdate = forceUpdate;
+    Q_EMIT forceUpdateChanged(m_forceUpdate);
 }
 
 bool UpdateModel::isCommunitySystem() const

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -92,6 +92,8 @@ class UpdateModel : public QObject
     Q_PROPERTY(QString upgradeUploadSpeedLimitRate READ upgradeUploadSpeedLimitRate NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeUploadSpeedEnable READ upgradeUploadSpeedEnable NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeDeliveryEnable READ upgradeDeliveryEnable NOTIFY upgradeDeliveryEnableChanged FINAL)
+    Q_PROPERTY(bool p2pUpdateEnabled READ isP2PUpdateEnabled NOTIFY p2pUpdateEnableStateChanged FINAL)
+    Q_PROPERTY(bool forceUpdate READ forceUpdate NOTIFY forceUpdateChanged FINAL)
     Q_PROPERTY(UpdateHistoryModel *historyModel READ historyModel NOTIFY historyModelChanged FINAL)
 
 
@@ -282,18 +284,18 @@ public:
     DownloadSpeedLimitConfig speedLimitConfig() const;
     void setSpeedLimitConfig(const QByteArray &config);
 
-    void setUpgradeDownloadSpeedLimitConfig(const QByteArray& config);
+    void setUpgradeDownloadSpeedLimitConfig(const QByteArray& config, bool needEmitSignal = true);
     QString upgradeDownloadSpeedCurrentRate() const;
     QString upgradeDownloadSpeedLimitRate() const;
     bool upgradeDownloadSpeedEnable() const;
     bool upgradeDownloadSpeedIsOnline() const;
-    UpgradeSpeedLimitConfig upgradeDownloadSpeedLimitConfig() const;
-    void setUpgradeUploadSpeedLimitConfig(const QByteArray& config);
+    LastoreUpgradeSpeedLimitConfig upgradeDownloadSpeedLimitConfig() const;
+    void setUpgradeUploadSpeedLimitConfig(const QByteArray& config, bool needEmitSignal = true);
     QString upgradeUploadSpeedCurrentRate() const;
     QString upgradeUploadSpeedLimitRate() const;
     bool upgradeUploadSpeedEnable() const;
     bool upgradeUploadSpeedIsOnline() const;
-    UpgradeSpeedLimitConfig upgradeUploadSpeedLimitConfig() const;
+    LastoreUpgradeSpeedLimitConfig upgradeUploadSpeedLimitConfig() const;
     bool upgradeDeliveryEnable() const;
 
     void setUpgradeDeliveryEnable(bool enable);
@@ -346,6 +348,9 @@ public:
 
     bool isP2PUpdateEnabled() const { return m_p2pUpdateEnabled; }
     void setP2PUpdateEnabled(bool enabled);
+
+    bool forceUpdate() const { return m_forceUpdate; }
+    void setForceUpdate();
 
 
     Q_INVOKABLE bool isCommunitySystem() const;
@@ -436,6 +441,7 @@ Q_SIGNALS:
     void showVersionChanged(QString version);
     void baselineChanged(const QString &baseline);
     void p2pUpdateEnableStateChanged(bool enabled);
+    void forceUpdateChanged(bool forceUpdate);
     void historyModelChanged();
 
 private:
@@ -516,6 +522,7 @@ private:
     QString m_showVersion;
     QString m_baseline;
     bool m_p2pUpdateEnabled;
+    bool m_forceUpdate;
 
     // update history qml data
     UpdateHistoryModel *m_historyModel;

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -38,6 +38,7 @@ const QString ServiceLinkCN = QStringLiteral("https://insider.deepin.org.cn");
 const QString ChangeLogFile = "/usr/share/deepin/release-note/UpdateInfo.json";
 const QString ChangeLogDic = "/usr/share/deepin/";
 const QString UpdateLogTmpFile = "/tmp/deepin-update-log.json";
+const QString AuthFailed = "authentication failed";
 
 const int LOWEST_BATTERY_PERCENT = 60;
 
@@ -182,6 +183,9 @@ void UpdateWorker::initConnect()
     connect(m_updateInter, &UpdateDBusProxy::AutoCleanChanged, m_model, &UpdateModel::setAutoCleanCache);
     connect(m_updateInter, &UpdateDBusProxy::AutoDownloadUpdatesChanged, m_model, &UpdateModel::setAutoDownloadUpdates);
     connect(m_updateInter, &UpdateDBusProxy::MirrorSourceChanged, m_model, &UpdateModel::setDefaultMirror);
+    connect(m_updateInter, &UpdateDBusProxy::P2PUpdateSupportChanged, this, [this](bool supported) {
+        Q_EMIT p2PUpdateSupportChanged(supported);
+    });
     if (IsCommunitySystem) {
         connect(m_updateInter, &UpdateDBusProxy::EnableChanged, m_model, &UpdateModel::setSmartMirrorSwitch);
     }
@@ -244,6 +248,7 @@ void UpdateWorker::activate()
     m_model->setUpdateNotify(m_updateInter->updateNotify());
     m_model->setAutoCleanCache(m_updateInter->autoClean());
     m_model->setP2PUpdateEnabled(m_updateInter->p2pUpdateEnable());
+    m_model->setForceUpdate();
     m_model->setImmutableAutoRecovery(m_updateInter->immutableAutoRecovery());
     if (IsCommunitySystem) {
         qCDebug(logDccUpdatePlugin) << "community system, enable smarrt mirror switch";
@@ -303,9 +308,11 @@ void UpdateWorker::initConfig()
                     qCDebug(logDccUpdatePlugin) << "Lastore daemon status changed:" << value;
                     m_model->setLastoreDaemonStatus(value);
                 }
+                m_model->setForceUpdate();
             }
             if ("update-time" == key) {
                 m_model->setScheduledUpgradeTime();
+                m_model->setForceUpdate();
             }
         });
     } else {
@@ -1287,12 +1294,28 @@ void UpdateWorker::initTestingChannel()
     });
 }
 
+QString UpdateWorker::transferDeliveryConfigToLastoreDeliveryConfig(const QString& deliveryConfig)
+{
+    qCDebug(logDccUpdatePlugin) << "xiongbo55555 transferDeliveryConfigToLastoreDeliveryConfig " << deliveryConfig;
+    LastoreUpgradeSpeedLimitConfig lastoreDeliveryConfig;
+    lastoreDeliveryConfig.isOnlineSpeedLimit = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).ifInOnlineLimit();
+    lastoreDeliveryConfig.speedLimitEnabled = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).shouldLimitRate();
+    lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).currentRate);
+    qCDebug(logDccUpdatePlugin) << "xiongbo55555 " << lastoreDeliveryConfig.toJson();
+    return lastoreDeliveryConfig.toJson();
+}
+
 void UpdateWorker::refreshUpgradeDeliveryInfo()
 {
     qCDebug(logDccUpdatePlugin) << "Refresh upgrade delivery info";
-    m_model->setUpgradeDownloadSpeedLimitConfig(m_updateAssistant->downloadLimitSpeed().toUtf8());
-    m_model->setUpgradeUploadSpeedLimitConfig(m_updateAssistant->uploadLimitSpeed().toUtf8());
+    m_model->setUpgradeDownloadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->downloadLimitSpeed()).toUtf8());
+    m_model->setUpgradeUploadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->uploadLimitSpeed()).toUtf8());
     m_model->setUpgradeDeliveryEnable(m_updateInter->p2pUpdateEnable());
+}
+
+bool UpdateWorker::p2pUpdateSupported() const
+{
+    return m_updateInter && m_updateInter->p2PUpdateSupport();
 }
 
 void UpdateWorker::checkTestingChannelStatus()
@@ -1731,9 +1754,9 @@ void UpdateWorker::onRemovePackageStatusChanged(const QString& value)
 }
 
 //更新传递总开关
-void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled)
+void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled, bool fromRetryDialog)
 {
-    if (enabled == m_model->upgradeDeliveryEnable()) {
+    if (enabled == m_model->upgradeDeliveryEnable() && !fromRetryDialog) {
         return;
     }
 
@@ -1741,8 +1764,8 @@ void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled)
     auto func_set_success = [=](bool enabled) {
         qCDebug(logDccUpdatePlugin) << "Set update assistant service succeed, enabled " << enabled;
         if (m_updateAssistant && m_model) {
-            m_model->setUpgradeDownloadSpeedLimitConfig(m_updateAssistant->downloadLimitSpeed().toUtf8());
-            m_model->setUpgradeUploadSpeedLimitConfig(m_updateAssistant->uploadLimitSpeed().toUtf8());
+            m_model->setUpgradeDownloadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->downloadLimitSpeed()).toUtf8());
+            m_model->setUpgradeUploadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->uploadLimitSpeed()).toUtf8());
             m_model->setUpgradeDeliveryEnable(enabled);
         }
     };
@@ -1752,7 +1775,8 @@ void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled)
         if (watcher->isError()) {
             qCWarning(logDccUpdatePlugin) << "Set update assistant service failed, enabled " << enabled << " error: " << watcher->error().message();
             m_model->setUpgradeDeliveryEnable(!enabled);
-            Q_EMIT upgradeDeliveryEnableSetFailed();
+            if (watcher->error().message() != AuthFailed)
+                Q_EMIT upgradeDeliveryEnableSetFailed();
             return;
         }
         func_set_success(enabled);
@@ -1762,18 +1786,22 @@ void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled)
 //设置更新传递下载限速
 void UpdateWorker::setUpgradeDeliveryDownloadLimitSpeed(const QString& speed, bool enable)
 {
+    qCInfo(logDccUpdatePlugin) << "xiongbo123 speed: " << speed;
     LastoreUpgradeSpeedLimitConfig downloadSpeedLimitConfig;
     downloadSpeedLimitConfig.isOnlineSpeedLimit = false;
     downloadSpeedLimitConfig.speedLimitEnabled = enable;
-    downloadSpeedLimitConfig.limitSpeed = speed;
+    downloadSpeedLimitConfig.limitSpeed = QString::number(speed.toInt() * 1024);
     qCInfo(logDccUpdatePlugin) << "Set upgrade download speed limit: " << downloadSpeedLimitConfig.toJson();
     auto watcher = new QDBusPendingCallWatcher(m_updateInter->SetUpgradeDeliveryDownloadSpeedLimit(downloadSpeedLimitConfig.toJson()), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this] {
+    connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this, downloadSpeedLimitConfig] {
         watcher->deleteLater();
         if (watcher->isError()) {
             qCWarning(logDccUpdatePlugin) << "Set upgrade download speed limit config error: " << watcher->error().message();
             getUpgradeDeliveryDownloadLimitSpeed();
+            Q_EMIT upgradeDeliveryConfigSetFailed();
+            return;
         }
+        m_model->setUpgradeDownloadSpeedLimitConfig(downloadSpeedLimitConfig.toJson().toUtf8(), false);
     });
 }
 
@@ -1783,29 +1811,32 @@ void UpdateWorker::setUpgradeDeliveryUploadLimitSpeed(const QString& speed, bool
     LastoreUpgradeSpeedLimitConfig uploadSpeedLimitConfig;
     uploadSpeedLimitConfig.isOnlineSpeedLimit = false;
     uploadSpeedLimitConfig.speedLimitEnabled = enable;
-    uploadSpeedLimitConfig.limitSpeed = speed;
+    uploadSpeedLimitConfig.limitSpeed = QString::number(speed.toInt() * 1024);
     qCInfo(logDccUpdatePlugin) << "Set upgrade upload speed limit: " << uploadSpeedLimitConfig.toJson();
     auto watcher = new QDBusPendingCallWatcher(m_updateInter->SetUpgradeDeliveryUploadSpeedLimit(uploadSpeedLimitConfig.toJson()), this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this] {
+    connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this, uploadSpeedLimitConfig] {
         watcher->deleteLater();
         if (watcher->isError()) {
             qCWarning(logDccUpdatePlugin) << "Set upgrade upload speed limit config error: " << watcher->error().message();
             getUpgradeDeliveryUploadLimitSpeed();
+            Q_EMIT upgradeDeliveryConfigSetFailed();
+            return;
         }
+        m_model->setUpgradeUploadSpeedLimitConfig(uploadSpeedLimitConfig.toJson().toUtf8(), false);
     });
 }
 
 void UpdateWorker::getUpgradeDeliveryDownloadLimitSpeed()
 {
     if (m_updateAssistant && m_model) {
-        m_model->setUpgradeDownloadSpeedLimitConfig(m_updateAssistant->downloadLimitSpeed().toUtf8());
+        m_model->setUpgradeDownloadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->downloadLimitSpeed()).toUtf8());
     }
 }
 
 void UpdateWorker::getUpgradeDeliveryUploadLimitSpeed()
 {
     if (m_updateAssistant && m_model) {
-        m_model->setUpgradeUploadSpeedLimitConfig(m_updateAssistant->uploadLimitSpeed().toUtf8());
+        m_model->setUpgradeUploadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(m_updateAssistant->uploadLimitSpeed()).toUtf8());
     }
 }
 

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -74,7 +74,7 @@ public:
     Q_INVOKABLE void setIdleDownloadEnabled(bool enable);
     Q_INVOKABLE void setIdleDownloadBeginTime(QString time);
     Q_INVOKABLE void setIdleDownloadEndTime(QString time);
-    Q_INVOKABLE void setUpgradeDeliveryEnabled(bool enabled);
+    Q_INVOKABLE void setUpgradeDeliveryEnabled(bool enabled, bool fromRetryDialog = false);
     Q_INVOKABLE void setUpgradeDeliveryDownloadLimitSpeed(const QString& speed, bool enable);
     Q_INVOKABLE void setUpgradeDeliveryUploadLimitSpeed(const QString& speed, bool enable);
     Q_INVOKABLE void getUpgradeDeliveryDownloadLimitSpeed();
@@ -101,6 +101,7 @@ public:
     Q_INVOKABLE void setTestingChannelEnable(const bool& enable);
     Q_INVOKABLE bool openTestingChannelUrl();
     Q_INVOKABLE void exitTestingChannel(bool value);
+    Q_INVOKABLE bool p2pUpdateSupported() const;
     std::optional<QString> getMachineId();
     std::optional<QUrl> getTestingChannelUrl();
     void initTestingChannel();
@@ -109,6 +110,7 @@ public:
     void setRemovePackageJob(const QString& jobPath);
     QString getServiceUrlByRegion();
     void refreshUpgradeDeliveryInfo();
+    QString transferDeliveryConfigToLastoreDeliveryConfig(const QString& deliveryConfig);
 
     Q_INVOKABLE bool openUrl(const QString& url);
     Q_INVOKABLE void onRequestRetry(int type, int updateTypes);
@@ -137,6 +139,8 @@ Q_SIGNALS:
     void requestCloseTestingChannel();
     void startDoUpgrade();
     void upgradeDeliveryEnableSetFailed();
+    void upgradeDeliveryConfigSetFailed();
+    void p2PUpdateSupportChanged(bool supported);
 
 private:
     Dtk::Core::DConfig *m_lastoreDConfig;

--- a/src/dcc-update-plugin/qml/UpdateControl.qml
+++ b/src/dcc-update-plugin/qml/UpdateControl.qml
@@ -23,6 +23,8 @@ ColumnLayout {
     property bool processState: false
     property bool busyState: false
     property bool updateListEnable: true
+    property bool buttonsEnabled: true
+    property var buttonEnabledStates: []
     property bool updateListcheck: true
     property bool isDownloading: false
     property bool isPauseOrNot: false
@@ -133,7 +135,9 @@ ColumnLayout {
                 text: modelData
                 font: D.DTK.fontManager.t6
                 visible: rootLayout.showActionButtons && modelData.length !== 0 && !initAnimation.visible
-                enabled: updatelistModel.model.isUpdateEnable
+                enabled: rootLayout.buttonsEnabled
+                    && updatelistModel.model.isUpdateEnable
+                    && (rootLayout.buttonEnabledStates.length <= index || rootLayout.buttonEnabledStates[index])
                 onClicked: {
                     rootLayout.btnClicked(index, updateListModels.getAllUpdateType())
                 }

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.0
 import QtQuick.Controls 2.0
@@ -38,7 +38,7 @@ Rectangle {
                 cascadeSelected: true
                 contentFlow: true
                 spacing: 0
-                
+
                 property bool showDetails: false
 
                 content: RowLayout {
@@ -62,7 +62,8 @@ Rectangle {
                                 Layout.alignment: Qt.AlignLeft
                                 text: model.title
                                 font: D.DTK.fontManager.t6
-                                color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
+                                                          Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                                 width: 100
                                 Layout.fillWidth: true
                             }
@@ -85,7 +86,8 @@ Rectangle {
                             horizontalAlignment: Text.AlignLeft
                             Layout.fillWidth: true
                             font: D.DTK.fontManager.t8
-                            color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                            color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
+                                                      Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                             visible: model.version.length !== 0
                             text: qsTr("Version:") + model.version
                         }
@@ -100,7 +102,7 @@ Rectangle {
                             wrapMode: Text.WordWrap
                             onLinkActivated: (link)=> {
                                 dccData.work().openUrl(link)
-                            }  
+                            }
                         }
 
                         RowLayout {
@@ -115,122 +117,123 @@ Rectangle {
                                 text: qsTr("Release time:") + model.releaseTime
                             }
 
-                            Item {
-                                Layout.fillWidth: true
-                            }
-                        }
-                    }
-                }
-
-                D.ToolButton {
-                    textColor: D.Palette {
-                        normal {
-                            common: D.DTK.makeColor(D.Color.Highlight)
-                        }
-                        normalDark: normal
-                        hovered {
-                            common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
-                        }
-                        hoveredDark: hovered
-                    }
-                    visible: repeater.model.getDetailInfos(index).length !== 0 && !itemCtl.showDetails
-                    bottomPadding: 0
-                    font: D.DTK.fontManager.t8
-                    text: qsTr("View More")
-                    onClicked: {
-                        itemCtl.showDetails = true
-                    }
-                    background: Item {}
-                }
-
-                Component.onDestruction: {
-                    itemCtl.showDetails = false
-                }
-            }
-
-            Rectangle {
-                height: 1
-                color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
-                            Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
-                Layout.fillWidth: true
-                visible: itemCtl.showDetails
-            }
-
-            // 详情列表
-            Repeater {
-                id: innerRepeater
-                model: repeater.model.getDetailInfos(index)
-                ColumnLayout {
-                    spacing: 6
-
-                    D.Label {
-                        Layout.alignment: Qt.AlignLeft
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.fillWidth: true
-                        font: D.DTK.fontManager.t8
-                        color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
-                                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-                        visible: itemCtl.showDetails && modelData.name !== ""
-                        text: qsTr("Version:") + modelData.name
-                    }
-
-                    D.Label {
-                        Layout.alignment: Qt.AlignLeft
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.fillWidth: true
-                        font: D.DTK.fontManager.t8
-                        visible: itemCtl.showDetails && modelData.info !== ""
-                        text: modelData.info
-                        textFormat: Text.RichText
-                        wrapMode: Text.WordWrap
-                        onLinkActivated: (link)=> {
-                            dccData.work().openUrl(link)
-                        }
-                    }
-
-                    RowLayout {
-                        D.Label {
-                            Layout.alignment: Qt.AlignLeft
-                            horizontalAlignment: Text.AlignLeft
-                            Layout.fillWidth: true
-                            font: D.DTK.fontManager.t8
-                            visible: itemCtl.showDetails && modelData.updateTime !== ""
-                            text: qsTr("Release time:") + modelData.updateTime
-                        }
-
-                        D.ToolButton {
-                            textColor: D.Palette {
-                                normal {
-                                    common: D.DTK.makeColor(D.Color.Highlight)
+                            D.ToolButton {
+                                textColor: D.Palette {
+                                    normal {
+                                        common: D.DTK.makeColor(D.Color.Highlight)
+                                    }
+                                    normalDark: normal
+                                    hovered {
+                                        common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
+                                    }
+                                    hoveredDark: hovered
                                 }
-                                normalDark: normal
-                                hovered {
-                                    common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
+                                // visible: repeater.model.getDetailInfos(index).length !== 0 && !itemCtl.showDetails
+                                visible: true
+                                bottomPadding: 0
+                                font: D.DTK.fontManager.t8
+                                text: qsTr("View More")
+                                onClicked: {
+                                    itemCtl.showDetails = true
                                 }
-                                hoveredDark: hovered
+                                background: Item {}
                             }
-                            visible: itemCtl.showDetails && (index === innerRepeater.count - 1 )
-                            bottomPadding: 0
-                            font: D.DTK.fontManager.t8
-                            text: qsTr("Collapse")
-                            onClicked: {
+
+                            Component.onDestruction: {
                                 itemCtl.showDetails = false
                             }
-                            background: Item {}
                         }
 
-                        Component.onDestruction: {
-                            itemCtl.showDetails = false
+                        Rectangle {
+                            height: 1
+                            color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
+                                                       Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
+                            Layout.fillWidth: true
+                            visible: itemCtl.showDetails
+                        }
+
+                        // 详情列表
+                        Repeater {
+                            id: innerRepeater
+                            model: repeater.model.getDetailInfos(index)
+                            ColumnLayout {
+                                spacing: 6
+
+                                D.Label {
+                                    Layout.alignment: Qt.AlignLeft
+                                    horizontalAlignment: Text.AlignLeft
+                                    Layout.fillWidth: true
+                                    font: D.DTK.fontManager.t8
+                                    color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
+                                                              Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                    visible: itemCtl.showDetails && modelData.name !== ""
+                                    text: qsTr("Version:") + modelData.name
+                                }
+
+                                D.Label {
+                                    Layout.alignment: Qt.AlignLeft
+                                    horizontalAlignment: Text.AlignLeft
+                                    Layout.fillWidth: true
+                                    font: D.DTK.fontManager.t8
+                                    visible: itemCtl.showDetails && modelData.info !== ""
+                                    text: modelData.info
+                                    textFormat: Text.RichText
+                                    wrapMode: Text.WordWrap
+                                    onLinkActivated: (link)=> {
+                                        dccData.work().openUrl(link)
+                                    }
+                                }
+
+                                RowLayout {
+                                    D.Label {
+                                        Layout.alignment: Qt.AlignLeft
+                                        horizontalAlignment: Text.AlignLeft
+                                        Layout.fillWidth: true
+                                        font: D.DTK.fontManager.t8
+                                        visible: itemCtl.showDetails && modelData.updateTime !== ""
+                                        text: qsTr("Release time:") + modelData.updateTime
+                                    }
+
+                                    D.ToolButton {
+                                        textColor: D.Palette {
+                                            normal {
+                                                common: D.DTK.makeColor(D.Color.Highlight)
+                                            }
+                                            normalDark: normal
+                                            hovered {
+                                                common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
+                                            }
+                                            hoveredDark: hovered
+                                        }
+                                        visible: itemCtl.showDetails && (index === innerRepeater.count - 1 )
+                                        bottomPadding: 0
+                                        font: D.DTK.fontManager.t8
+                                        text: qsTr("Collapse")
+                                        onClicked: {
+                                            itemCtl.showDetails = false
+                                        }
+                                        background: Item {}
+                                    }
+
+                                    Component.onDestruction:   {
+                                        itemCtl.showDetails = false
+                                    }
+                                }
+
+                                Rectangle {
+                                    height: 1
+                                    color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
+                                                               Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
+                                    Layout.fillWidth: true
+                                    visible: itemCtl.showDetails && (index !== innerRepeater.count - 1 )
+                                }
+                            }
                         }
                     }
+                }
 
-                    Rectangle {
-                        height: 1
-                        color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
-                                        Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
-                        Layout.fillWidth: true
-                        visible: itemCtl.showDetails && (index !== innerRepeater.count - 1 )
-                    }
+                background: DccItemBackground {
+                    separatorVisible: true
                 }
             }
         }

--- a/src/dcc-update-plugin/qml/UpdateMain.qml
+++ b/src/dcc-update-plugin/qml/UpdateMain.qml
@@ -311,6 +311,9 @@ DccObject {
             Component.onCompleted: updateSecondaryTips()
             busyState: dccData.model().upgradeWaiting
             updateListEnable: !dccData.model().upgradeWaiting
+            buttonEnabledStates: dccData.model().isPrivateUpdate
+                ? [!dccData.model().forceUpdate, true]
+                : [true]
 
             onBtnClicked: function(index, updateType) {
                 if (index === 0) {

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -13,16 +13,18 @@ import org.deepin.dcc.update 1.0
 
 DccObject {
     id: root
+    property bool syncingUpgradeDeliverySwitch: false
+    property bool pendingUpgradeDeliveryEnabled: dccData.model().upgradeDeliveryEnable
 
     FontMetrics {
         id: fm
     }
 
     D.DialogWindow {
-        id: upgradeDeliveryFailedDialog
+        id: upgradeDeliverySetConfigFailedDialog
         width: 360
         icon: "preferences-system"
-        modality: Qt.WindowModal
+        modality: Qt.ApplicationModal
         visible: false
 
         ColumnLayout {
@@ -48,9 +50,9 @@ DccObject {
                 ButtonWithToolTip {
                     text: qsTr("OK")
                     Layout.fillWidth: true
-                    focus: upgradeDeliveryFailedDialog.visible
+                    focus: upgradeDeliverySetConfigFailedDialog.visible
                     onClicked: {
-                        upgradeDeliveryFailedDialog.close()
+                        upgradeDeliverySetConfigFailedDialog.close()
                     }
                 }
 
@@ -82,8 +84,86 @@ DccObject {
 
     Connections {
         target: dccData.work()
+        function onUpgradeDeliveryConfigSetFailed() {
+            upgradeDeliverySetConfigFailedDialog.show()
+        }
+    }
+
+    D.DialogWindow {
+        id: upgradeDeliverySetEnableFailedDialog
+        width: 360
+        icon: "preferences-system"
+        modality: Qt.ApplicationModal
+        visible: false
+
+        ColumnLayout {
+            width: parent.width
+
+            D.Label {
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                text: qsTr("Failed to change Upgrade Delivery setting")
+            }
+
+            Item {
+                Layout.fillHeight: true
+                Layout.preferredHeight: 22
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.bottomMargin: 10
+                spacing: 10
+
+                EnableFailedDialogButton {
+                    text: qsTr("Retry")
+                    Layout.fillWidth: true
+                    focus: upgradeDeliverySetEnableFailedDialog.visible
+                    onClicked: {
+                        upgradeDeliverySetEnableFailedDialog.close()
+                        dccData.work().setUpgradeDeliveryEnabled(!root.pendingUpgradeDeliveryEnabled, true)
+                    }
+                }
+
+                EnableFailedDialogButton {
+                    text: qsTr("OK")
+                    Layout.fillWidth: true
+                    onClicked: {
+                        upgradeDeliverySetEnableFailedDialog.close()
+                    }
+                }
+
+                component EnableFailedDialogButton: D.Button {
+                    id: customButton
+
+                    contentItem: Text {
+                        id: buttonText
+                        text: customButton.text
+                        font: customButton.font
+                        color: customButton.D.ColorSelector.textColor
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
+                        elide: Text.ElideRight
+                        width: customButton.width
+                    }
+
+                    hoverEnabled: true
+
+                    ToolTip {
+                        visible: customButton.hovered && buttonText.truncated
+                        delay: 500
+                        text: customButton.text
+                    }
+                }
+            }
+        }
+    }
+
+    Connections {
+        target: dccData.work()
         function onUpgradeDeliveryEnableSetFailed() {
-            upgradeDeliveryFailedDialog.show()
+            upgradeDeliverySetEnableFailedDialog.show()
         }
     }
 
@@ -234,19 +314,28 @@ DccObject {
         }
 
         DccObject {
+            id: upgradeDeliveryGrp
             name: "upgradeDeliveryGrp"
             parentName: "advancedSettingGroup"
             weight: 40
+            visible: dccData.work().p2pUpdateSupported()
             pageType: DccObject.Item
             page: DccGroupView {
                 height: implicitHeight + 10
                 spacing: 0
+            }
+            Connections {
+                target: dccData.work()
+                function onP2PUpdateSupportChanged() {
+                    upgradeDeliveryGrp.visible = dccData.work().p2pUpdateSupported()
+                }
             }
 
             DccObject {
                 name: "upgradeDeliverySwitch"
                 parentName: "upgradeDeliveryGrp"
                 displayName: qsTr("Upgrade Delivery")
+                description: qsTr("Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart")
                 weight: 10
                 enabled: !dccData.model().updateProhibited
                 pageType: DccObject.Editor
@@ -254,102 +343,18 @@ DccObject {
                     id: upgradeDeliverySwitch
                     checked: dccData.model().upgradeDeliveryEnable
                     onCheckedChanged: {
+                        if (root.syncingUpgradeDeliverySwitch) {
+                            return
+                        }
+                        root.pendingUpgradeDeliveryEnabled = checked
                         dccData.work().setUpgradeDeliveryEnabled(checked)
                     }
                     Connections {
                         target: dccData.model()
                         function onUpgradeDeliveryEnableChanged() {
+                            root.syncingUpgradeDeliverySwitch = true
                             upgradeDeliverySwitch.checked = dccData.model().upgradeDeliveryEnable
-                        }
-                    }
-                }
-            }
-
-            DccObject {
-                name: "upgradeDeliveryDownloadLimitSetting"
-                parentName: "upgradeDeliveryGrp"
-                displayName: qsTr("Upgrade Delivery Download Limit Setting")
-                visible: dccData.model().upgradeDeliveryEnable
-                weight: 20
-                enabled: !dccData.model().upgradeDownloadSpeedIsOnline
-                pageType: DccObject.Item
-                property bool isInitializing: true
-                page: RowLayout {
-                    D.CheckBox {
-                        id: limitCheckBox
-                        Layout.leftMargin: 14
-                        Layout.fillWidth: true
-                        text: dccObj.displayName
-                        checked: dccData.model().upgradeDownloadSpeedEnable
-                        Connections {
-                            target: dccData.model()
-                            function onUpgradeDownloadSpeedLimitConfigChanged() {
-                                limitCheckBox.checked = dccData.model().upgradeDownloadSpeedEnable
-                            }
-                        }
-                        onCheckedChanged: {
-                            if (dccObj.isInitializing) {
-                                dccObj.isInitializing = false
-                                return
-                            }
-                            if (limitCheckBox.checked) {
-                                dccData.work().setUpgradeDeliveryDownloadLimitSpeed(lineEdit.text, limitCheckBox.checked)
-                            } else {
-                                dccData.work().setUpgradeDeliveryDownloadLimitSpeed("102400", limitCheckBox.checked)
-                            }
-                        }
-                    }
-
-                    RowLayout {
-                        spacing: 10
-                        Layout.topMargin: 5
-                        Layout.bottomMargin: 5
-                        Layout.rightMargin: 10
-                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                        D.LineEdit {
-                            id: lineEdit
-                            maximumLength: 6
-                            validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
-                            alertText: qsTr("Only numbers between 10-999999 are allowed")
-                            alertDuration: 3000
-                            clearButton.active: lineEdit.activeFocus && (text.length !== 0)
-                            text: dccData.model().upgradeDownloadSpeedCurrentRate
-
-                            onTextChanged: {
-                                if (lineEdit.text.length !== 0 && (lineEdit.text[0] === "0" || Number(lineEdit.text) > 999999)) {
-                                    lineEdit.text = ""
-                                    lineEdit.showAlert = true
-                                } else if (lineEdit.showAlert && (lineEdit.text.length === 0 || (Number(lineEdit.text) >= 10 && Number(lineEdit.text) <= 999999))) {
-                                    lineEdit.showAlert = false
-                                }
-                            }
-                            onEditingFinished: {
-                                if (lineEdit.text.length === 0) {
-                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
-                                    return
-                                }
-                                if (Number(lineEdit.text) < 10 || Number(lineEdit.text) > 999999) {
-                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
-                                    lineEdit.showAlert = true
-                                    return
-                                }
-                                dccData.work().setUpgradeDeliveryDownloadLimitSpeed(lineEdit.text, limitCheckBox.checked)
-                            }
-                            Keys.onPressed: {
-                                if (event.key === Qt.Key_Return) {
-                                    lineEdit.forceActiveFocus(false);
-                                }
-                            }
-                            Connections {
-                                target: dccData.model()
-                                function onUpgradeDownloadSpeedLimitConfigChanged() {
-                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
-                                }
-                            }
-                        }
-
-                        D.Label {
-                            text: "KB/S"
+                            root.syncingUpgradeDeliverySwitch = false
                         }
                     }
                 }
@@ -363,7 +368,6 @@ DccObject {
                 weight: 20
                 enabled: !dccData.model().upgradeUploadSpeedIsOnline
                 pageType: DccObject.Item
-                property bool isInitializing: true
                 page: RowLayout {
                     D.CheckBox {
                         id: limitCheckBox
@@ -378,15 +382,7 @@ DccObject {
                             }
                         }
                         onCheckedChanged: {
-                            if (dccObj.isInitializing) {
-                                dccObj.isInitializing = false
-                                return
-                            }
-                            if (limitCheckBox.checked) {
-                                dccData.work().setUpgradeDeliveryUploadLimitSpeed(lineEdit.text, limitCheckBox.checked)
-                            } else {
-                                dccData.work().setUpgradeDeliveryUploadLimitSpeed("102400", limitCheckBox.checked)
-                            }
+                            dccData.work().setUpgradeDeliveryUploadLimitSpeed(lineEdit.text, limitCheckBox.checked)
                         }
                     }
 
@@ -402,13 +398,25 @@ DccObject {
                             validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
                             alertText: qsTr("Only numbers between 10-999999 are allowed")
                             alertDuration: 3000
+                            enabled: limitCheckBox.checked
                             clearButton.active: lineEdit.activeFocus && (text.length !== 0)
                             text: dccData.model().upgradeUploadSpeedCurrentRate
+
+                            function triggerAlert() {
+                                lineEdit.showAlert = true
+                                alertResetTimer.restart()
+                            }
+
+                            Timer {
+                                id: alertResetTimer
+                                interval: lineEdit.alertDuration
+                                onTriggered: lineEdit.showAlert = false
+                            }
 
                             onTextChanged: {
                                 if (lineEdit.text.length !== 0 && (lineEdit.text[0] === "0" || Number(lineEdit.text) > 999999)) {
                                     lineEdit.text = ""
-                                    lineEdit.showAlert = true
+                                    lineEdit.triggerAlert()
                                 } else if (lineEdit.showAlert && (lineEdit.text.length === 0 || (Number(lineEdit.text) >= 10 && Number(lineEdit.text) <= 999999))) {
                                     lineEdit.showAlert = false
                                 }
@@ -420,7 +428,7 @@ DccObject {
                                 }
                                 if (Number(lineEdit.text) < 10 || Number(lineEdit.text) > 999999) {
                                     lineEdit.text = dccData.model().upgradeUploadSpeedCurrentRate
-                                    lineEdit.showAlert = true
+                                    lineEdit.triggerAlert()
                                     return
                                 }
                                 dccData.work().setUpgradeDeliveryUploadLimitSpeed(lineEdit.text, limitCheckBox.checked)
@@ -434,6 +442,99 @@ DccObject {
                                 target: dccData.model()
                                 function onUpgradeUploadSpeedLimitConfigChanged() {
                                     lineEdit.text = dccData.model().upgradeUploadSpeedCurrentRate
+                                }
+                            }
+                        }
+
+                        D.Label {
+                            text: "KB/S"
+                        }
+                    }
+                }
+            }
+
+            DccObject {
+                name: "upgradeDeliveryDownloadLimitSetting"
+                parentName: "upgradeDeliveryGrp"
+                displayName: qsTr("Upgrade Delivery Download Limit Setting")
+                visible: dccData.model().upgradeDeliveryEnable
+                weight: 20
+                enabled: !dccData.model().upgradeDownloadSpeedIsOnline
+                pageType: DccObject.Item
+                page: RowLayout {
+                    D.CheckBox {
+                        id: limitCheckBox
+                        Layout.leftMargin: 14
+                        Layout.fillWidth: true
+                        text: dccObj.displayName
+                        checked: dccData.model().upgradeDownloadSpeedEnable
+                        Connections {
+                            target: dccData.model()
+                            function onUpgradeDownloadSpeedLimitConfigChanged() {
+                                limitCheckBox.checked = dccData.model().upgradeDownloadSpeedEnable
+                            }
+                        }
+                        onCheckedChanged: {
+                            dccData.work().setUpgradeDeliveryDownloadLimitSpeed(lineEdit.text, limitCheckBox.checked)
+                        }
+                    }
+
+                    RowLayout {
+                        spacing: 10
+                        Layout.topMargin: 5
+                        Layout.bottomMargin: 5
+                        Layout.rightMargin: 10
+                        Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                        D.LineEdit {
+                            id: lineEdit
+                            maximumLength: 6
+                            validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
+                            alertText: qsTr("Only numbers between 10-999999 are allowed")
+                            alertDuration: 3000
+                            enabled: limitCheckBox.checked
+                            clearButton.active: lineEdit.activeFocus && (text.length !== 0)
+                            text: dccData.model().upgradeDownloadSpeedCurrentRate
+
+                            function triggerAlert() {
+                                lineEdit.showAlert = true
+                                alertResetTimer.restart()
+                            }
+
+                            Timer {
+                                id: alertResetTimer
+                                interval: lineEdit.alertDuration
+                                onTriggered: lineEdit.showAlert = false
+                            }
+
+                            onTextChanged: {
+                                if (lineEdit.text.length !== 0 && (lineEdit.text[0] === "0" || Number(lineEdit.text) > 999999)) {
+                                    lineEdit.text = ""
+                                    lineEdit.triggerAlert()
+                                } else if (lineEdit.showAlert && (lineEdit.text.length === 0 || (Number(lineEdit.text) >= 10 && Number(lineEdit.text) <= 999999))) {
+                                    lineEdit.showAlert = false
+                                }
+                            }
+                            onEditingFinished: {
+                                if (lineEdit.text.length === 0) {
+                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
+                                    return
+                                }
+                                if (Number(lineEdit.text) < 10 || Number(lineEdit.text) > 999999) {
+                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
+                                    lineEdit.triggerAlert()
+                                    return
+                                }
+                                dccData.work().setUpgradeDeliveryDownloadLimitSpeed(lineEdit.text, limitCheckBox.checked)
+                            }
+                            Keys.onPressed: {
+                                if (event.key === Qt.Key_Return) {
+                                    lineEdit.forceActiveFocus(false);
+                                }
+                            }
+                            Connections {
+                                target: dccData.model()
+                                function onUpgradeDownloadSpeedLimitConfigChanged() {
+                                    lineEdit.text = dccData.model().upgradeDownloadSpeedCurrentRate
                                 }
                             }
                         }
@@ -471,14 +572,9 @@ DccObject {
                 weight: 10
                 enabled: !dccData.model().updateProhibited
                 pageType: DccObject.Editor
-                property bool isInitializing: true
                 page: D.Switch {
                     checked: dccData.model().downloadSpeedLimitEnabled || dccData.model().downloadIsOnlineSpeedLimit
                     onCheckedChanged: {
-                        if (dccObj.isInitializing) {
-                            dccObj.isInitializing = false
-                            return
-                        }
                         dccData.work().setDownloadSpeedLimitEnabled(checked)
                     }
                 }
@@ -497,23 +593,38 @@ DccObject {
                         id: lineEdit
                         maximumLength: 5
                         validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
-                        alertText: qsTr("Only numbers between 1-99999 are allowed")
+                        alertText: qsTr("Only numbers between 10-999999 are allowed")
                         alertDuration: 3000
                         clearButton.active: lineEdit.activeFocus && (text.length !== 0)
                         text: dccData.model().downloadSpeedLimitSize
 
+                        function triggerAlert() {
+                            lineEdit.showAlert = true
+                            alertResetTimer.restart()
+                        }
+
+                        Timer {
+                            id: alertResetTimer
+                            interval: lineEdit.alertDuration
+                            onTriggered: lineEdit.showAlert = false
+                        }
+
                         onTextChanged: {
-                            // 如果输入不为空且数字为0的情况，需要弹出提示且阻止继续输入
-                            if (lineEdit.text.length !== 0 && lineEdit.text[0] === "0") {
+                            if (lineEdit.text.length !== 0 && (lineEdit.text[0] === "0" || Number(lineEdit.text) > 999999)) {
                                 lineEdit.text = ""
-                                lineEdit.showAlert = true
-                            } else if (lineEdit.showAlert) {
+                                lineEdit.triggerAlert()
+                            } else if (lineEdit.showAlert && (lineEdit.text.length === 0 || (Number(lineEdit.text) >= 10 && Number(lineEdit.text) <= 999999))) {
                                 lineEdit.showAlert = false
                             }
                         }
                         onEditingFinished: {
                             if (lineEdit.text.length === 0) {
                                 lineEdit.text = dccData.model().downloadSpeedLimitSize
+                                return
+                            }
+                            if (Number(lineEdit.text) < 10 || Number(lineEdit.text) > 999999) {
+                                lineEdit.text = dccData.model().downloadSpeedLimitSize
+                                lineEdit.triggerAlert()
                                 return
                             }
                             dccData.work().setDownloadSpeedLimitSize(lineEdit.text)

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -444,15 +444,19 @@
     </message>
     <message>
         <source>Upgrade Delivery</source>
-        <translation>更新传递</translation>
+        <translation>传递优化</translation>
+    </message>
+    <message>
+        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <translation>开启此功能，你的设备可能会将以前下载的部分系统更新发送到本地网络的设备上。关闭此功能后，将在重启时清除传递优化时缓存的文件</translation>
     </message>
     <message>
         <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>更新传递-下载限速</translation>
+        <translation>下载限速</translation>
     </message>
     <message>
         <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>更新传递-上传限速</translation>
+        <translation>上传限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -528,7 +532,11 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新传递设置修改失败</translation>
+        <translation>更新传递优化服务异常，设置失败</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation>重试</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -447,6 +447,10 @@
         <translation>更新傳遞</translation>
     </message>
     <message>
+        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本地網絡的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
+    </message>
+    <message>
         <source>Upgrade Delivery Download Limit Setting</source>
         <translation>更新傳遞-下載限速</translation>
     </message>
@@ -524,7 +528,11 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新傳遞設定修改失敗</translation>
+        <translation>更新傳遞優化服務異常，設置失敗</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation>重試</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -447,6 +447,10 @@
         <translation>更新傳遞</translation>
     </message>
     <message>
+        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本機網路的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
+    </message>
+    <message>
         <source>Upgrade Delivery Download Limit Setting</source>
         <translation>更新傳遞-下載限速</translation>
     </message>
@@ -524,7 +528,11 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新傳遞設定修改失敗</translation>
+        <translation>更新傳遞優化服務異常，設置失敗</translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation>重試</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/private-lastore-tray/tipswidget.cpp
+++ b/src/private-lastore-tray/tipswidget.cpp
@@ -116,6 +116,16 @@ bool TipsWidget::hasUnfinishedJob(const QList<QDBusObjectPath> &jobs) const
     return false;
 }
 
+void TipsWidget::onSetUpdateProto(const QString& proto)
+{
+    m_proto = proto;
+}
+
+void TipsWidget::onSetUpdateSpeed(qlonglong speed)
+{
+    m_speed = speed;
+}
+
 void TipsWidget::onSetUpdateProgress(double progress)
 {
     m_updateProgress = progress;
@@ -255,6 +265,8 @@ void TipsWidget::onRefreshJobList(const QList<QDBusObjectPath> &jobs)
         if (id == "dist_upgrade" || id == "prepare_dist_upgrade") {
             m_updateJobInter = new UpdateJobDBusProxy(jobPath, this);
             connect(m_updateJobInter, &UpdateJobDBusProxy::ProgressChanged, this, &TipsWidget::onSetUpdateProgress);
+            connect(m_updateJobInter, &UpdateJobDBusProxy::ProtoChanged, this, &TipsWidget::onSetUpdateProto);
+            connect(m_updateJobInter, &UpdateJobDBusProxy::SpeedChanged, this, &TipsWidget::onSetUpdateSpeed);
         } else if (id == "backup") {
             m_backupJobInter = new UpdateJobDBusProxy(jobPath, this);
             connect(m_backupJobInter, &UpdateJobDBusProxy::ProgressChanged, this, &TipsWidget::onSetBackUpProgress);

--- a/src/private-lastore-tray/tipswidget.h
+++ b/src/private-lastore-tray/tipswidget.h
@@ -80,6 +80,8 @@ private slots:
     void onRefreshJobList(const QList<QDBusObjectPath> &jobs);
     void onSetUpdateProgress(double progress);
     void onSetBackUpProgress(double progress);
+    void onSetUpdateProto(const QString &proto);
+    void onSetUpdateSpeed(qlonglong speed);
 
 private:
     UpdateDBusProxy *m_managerInter = nullptr;
@@ -88,7 +90,7 @@ private:
     QString m_text;
     QStringList m_textList;
     ShowType m_type;
-    qulonglong m_speed = 0;
+    qlonglong m_speed = 0;
     QString m_proto = "";
     bool m_downloadLimitOnChanging = false;
     double m_updateProgress = 0.0;


### PR DESCRIPTION
修复如下问题：
1.服务端下发定时更新或者关机重启时更新，客户端下载成功之后，控制中心应该将立即更新按钮置灰
2.更新设置页面，传递优化配置项下方提示信息缺失
3.客户端接入企业更新管理系统后，控制中心-系统更新-更新设置中更新传递配置项应该隐藏
4.没有勾选更新传递上传和下载限速的值输入框建议置灰处理
5.更新传递配置项开关打开，重启系统，开关是关闭状态
6.更新传递配置项名字需要修改为传递优化

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-355953.html https://pms.uniontech.com/bug-view-356031.html
https://pms.uniontech.com/bug-view-356189.html
https://pms.uniontech.com/bug-view-356281.html
https://pms.uniontech.com/bug-view-356331.html
https://pms.uniontech.com/bug-view-356333.html
Influence：影响私有化更新场景下的控制中心交互逻辑