### PR TITLE
第四轮bug修复

### DIFF
--- a/src/dcc-update-plugin/operation/updatedatastructs.h
+++ b/src/dcc-update-plugin/operation/updatedatastructs.h
@@ -148,16 +148,10 @@ struct UpgradeSpeedLimitConfig {
     QDateTime endTime;      // 结束时间
 
     bool ifInOnlineLimit() const {
-        if (limitType != 3) {
-            return false;
-        }
-
-        if (!startTime.isValid() || !endTime.isValid()) {
-            return false;
-        }
+        if (limitType == 2)
+            return true;
         
-        QDateTime currentTime = QDateTime::currentDateTime();
-        return currentTime >= startTime && currentTime <= endTime;
+        return false;
     }
 
     bool shouldLimitRate() const {
@@ -185,7 +179,6 @@ struct UpgradeSpeedLimitConfig {
 
     static UpgradeSpeedLimitConfig fromJson(const QByteArray& configStr)
     {
-        qWarning() << "xiongbo123 fromJson: " << configStr;
         UpgradeSpeedLimitConfig config;
         QJsonParseError jsonParseError;
         const QJsonDocument doc = QJsonDocument::fromJson(configStr, &jsonParseError);
@@ -317,6 +310,15 @@ struct LastoreDaemonUpdateStatus {
         return lastoreDaemonUpdateStatus;
     }
 };
+
+inline QString transferDeliveryConfigToLastoreDeliveryConfig(const QString& deliveryConfig)
+{
+    LastoreUpgradeSpeedLimitConfig lastoreDeliveryConfig;
+    lastoreDeliveryConfig.isOnlineSpeedLimit = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).ifInOnlineLimit();
+    lastoreDeliveryConfig.speedLimitEnabled = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).shouldLimitRate();
+    lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).currentRate);
+    return lastoreDeliveryConfig.toJson();
+}
 
 const int INSTALLATION_IS_READY = 1 << 0; // 是否可以安装
 const int UPDATE_IS_DISABLED = 1 << 1; // 更新功能是否被禁用

--- a/src/dcc-update-plugin/operation/updateloghelper.cpp
+++ b/src/dcc-update-plugin/operation/updateloghelper.cpp
@@ -66,6 +66,7 @@ QString UpdateLogHelper::sumCveLevelUp(const QMap<VulLevel, int>& vulCount)
 
 void UpdateLogHelper::handleUpdateLog(const QString &log)
 {
+    qCDebug(logDccUpdatePlugin) << "Handling update log: " << log;
     qCDebug(logDccUpdatePlugin) << "Handling update log, length:" << log.length();
     const QJsonDocument& doc = QJsonDocument::fromJson(log.toLocal8Bit());
     const QJsonObject& rootObj = doc.object();

--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -1169,9 +1169,11 @@ DownloadSpeedLimitConfig UpdateModel::speedLimitConfig() const
     return DownloadSpeedLimitConfig::fromJson(m_speedLimitConfig);
 }
 
-void UpdateModel::setSpeedLimitConfig(const QByteArray& config)
+void UpdateModel::setSpeedLimitConfig(const QByteArray& config, bool isFromQml)
 {
     qCDebug(logDccUpdatePlugin) << "Set speed limit config:" << config;
+    if (DownloadSpeedLimitConfig::fromJson(m_speedLimitConfig).isOnlineSpeedLimit && isFromQml)
+        return;
     if (m_speedLimitConfig == config)
         return;
 
@@ -1523,7 +1525,6 @@ void UpdateModel::onUpdatePropertiesChanged(const QString& interfaceName, const 
 {
     qCDebug(logDccUpdatePlugin) << "Update properties changed for interface:" << interfaceName << "properties count:" << changedProperties.size();
     Q_UNUSED(invalidatedProperties)
-
     if (interfaceName == "org.deepin.dde.Lastore1.Manager") {
         qCDebug(logDccUpdatePlugin) << "Handling Lastore Manager property changes";
         if (changedProperties.contains("CheckUpdateMode")) {
@@ -1561,7 +1562,21 @@ void UpdateModel::onUpdatePropertiesChanged(const QString& interfaceName, const 
 
         if (changedProperties.contains("P2PUpdateEnable")) {
             qCDebug(logDccUpdatePlugin) << "P2PUpdateEnable property changed";
-            setP2PUpdateEnabled(changedProperties.value("P2PUpdateEnable").toBool());
+            setUpgradeDeliveryEnable(changedProperties.value("P2PUpdateEnable").toBool());
+        }
+    }
+
+    if (interfaceName == "org.deepin.upgradedelivery") {
+        qCDebug(logDccUpdatePlugin) << "Handling upgrade delivery property changes";
+        if (changedProperties.contains("DownloadLimitSpeed")) {
+            qCDebug(logDccUpdatePlugin) << "P2PUpgradeDownloadSpeedLimitConfig property changed";
+            qCDebug(logDccUpdatePlugin) << "P2PUpgradeDownloadSpeedLimitConfig property changed " << changedProperties.value("DownloadLimitSpeed");
+            setUpgradeDownloadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(changedProperties.value("DownloadLimitSpeed").toByteArray()).toUtf8());
+        }
+
+        if (changedProperties.contains("UploadLimitSpeed")) {
+            qCDebug(logDccUpdatePlugin) << "P2PUpgradeUploadSpeedLimitConfig property changed";
+            setUpgradeUploadSpeedLimitConfig(transferDeliveryConfigToLastoreDeliveryConfig(changedProperties.value("UploadLimitSpeed").toByteArray()).toUtf8());
         }
     }
 }

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -88,6 +88,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(QString upgradeDownloadSpeedCurrentRate READ upgradeDownloadSpeedCurrentRate NOTIFY upgradeDownloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString upgradeDownloadSpeedLimitRate READ upgradeDownloadSpeedLimitRate NOTIFY upgradeDownloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeDownloadSpeedEnable READ upgradeDownloadSpeedEnable NOTIFY upgradeDownloadSpeedLimitConfigChanged FINAL)
+    Q_PROPERTY(bool upgradeDownloadSpeedIsOnline READ upgradeDownloadSpeedIsOnline NOTIFY upgradeDownloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString upgradeUploadSpeedCurrentRate READ upgradeUploadSpeedCurrentRate NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString upgradeUploadSpeedLimitRate READ upgradeUploadSpeedLimitRate NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeUploadSpeedEnable READ upgradeUploadSpeedEnable NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
@@ -282,7 +283,7 @@ public:
     bool downloadIsOnlineSpeedLimit() const;
     QString downloadSpeedLimitSize() const;
     DownloadSpeedLimitConfig speedLimitConfig() const;
-    void setSpeedLimitConfig(const QByteArray &config);
+    void setSpeedLimitConfig(const QByteArray &config, bool isFromQml = false);
 
     void setUpgradeDownloadSpeedLimitConfig(const QByteArray& config, bool needEmitSignal = true);
     QString upgradeDownloadSpeedCurrentRate() const;

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -928,7 +928,7 @@ void UpdateWorker::setDownloadSpeedLimitEnabled(bool enable)
     config.downloadSpeedLimitEnabled = enable;
     config.isOnlineSpeedLimit = false;
     // dbus返回需要1s，导致界面更新慢，这里直接先更新model
-    m_model->setSpeedLimitConfig(config.toJson().toUtf8());
+    m_model->setSpeedLimitConfig(config.toJson().toUtf8(), true);
     setDownloadSpeedLimitConfig(config.toJson());
 }
 
@@ -1292,17 +1292,6 @@ void UpdateWorker::initTestingChannel()
         }
         watcher->deleteLater();
     });
-}
-
-QString UpdateWorker::transferDeliveryConfigToLastoreDeliveryConfig(const QString& deliveryConfig)
-{
-    qCDebug(logDccUpdatePlugin) << "xiongbo55555 transferDeliveryConfigToLastoreDeliveryConfig " << deliveryConfig;
-    LastoreUpgradeSpeedLimitConfig lastoreDeliveryConfig;
-    lastoreDeliveryConfig.isOnlineSpeedLimit = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).ifInOnlineLimit();
-    lastoreDeliveryConfig.speedLimitEnabled = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).shouldLimitRate();
-    lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).currentRate);
-    qCDebug(logDccUpdatePlugin) << "xiongbo55555 " << lastoreDeliveryConfig.toJson();
-    return lastoreDeliveryConfig.toJson();
 }
 
 void UpdateWorker::refreshUpgradeDeliveryInfo()
@@ -1786,11 +1775,10 @@ void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled, bool fromRetryDialog)
 //设置更新传递下载限速
 void UpdateWorker::setUpgradeDeliveryDownloadLimitSpeed(const QString& speed, bool enable)
 {
-    qCInfo(logDccUpdatePlugin) << "xiongbo123 speed: " << speed;
     LastoreUpgradeSpeedLimitConfig downloadSpeedLimitConfig;
     downloadSpeedLimitConfig.isOnlineSpeedLimit = false;
     downloadSpeedLimitConfig.speedLimitEnabled = enable;
-    downloadSpeedLimitConfig.limitSpeed = QString::number(speed.toInt() * 1024);
+    downloadSpeedLimitConfig.limitSpeed = speed;
     qCInfo(logDccUpdatePlugin) << "Set upgrade download speed limit: " << downloadSpeedLimitConfig.toJson();
     auto watcher = new QDBusPendingCallWatcher(m_updateInter->SetUpgradeDeliveryDownloadSpeedLimit(downloadSpeedLimitConfig.toJson()), this);
     connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this, downloadSpeedLimitConfig] {
@@ -1801,7 +1789,6 @@ void UpdateWorker::setUpgradeDeliveryDownloadLimitSpeed(const QString& speed, bo
             Q_EMIT upgradeDeliveryConfigSetFailed();
             return;
         }
-        m_model->setUpgradeDownloadSpeedLimitConfig(downloadSpeedLimitConfig.toJson().toUtf8(), false);
     });
 }
 
@@ -1811,7 +1798,7 @@ void UpdateWorker::setUpgradeDeliveryUploadLimitSpeed(const QString& speed, bool
     LastoreUpgradeSpeedLimitConfig uploadSpeedLimitConfig;
     uploadSpeedLimitConfig.isOnlineSpeedLimit = false;
     uploadSpeedLimitConfig.speedLimitEnabled = enable;
-    uploadSpeedLimitConfig.limitSpeed = QString::number(speed.toInt() * 1024);
+    uploadSpeedLimitConfig.limitSpeed = speed;
     qCInfo(logDccUpdatePlugin) << "Set upgrade upload speed limit: " << uploadSpeedLimitConfig.toJson();
     auto watcher = new QDBusPendingCallWatcher(m_updateInter->SetUpgradeDeliveryUploadSpeedLimit(uploadSpeedLimitConfig.toJson()), this);
     connect(watcher, &QDBusPendingCallWatcher::finished, [watcher, this, uploadSpeedLimitConfig] {
@@ -1822,7 +1809,6 @@ void UpdateWorker::setUpgradeDeliveryUploadLimitSpeed(const QString& speed, bool
             Q_EMIT upgradeDeliveryConfigSetFailed();
             return;
         }
-        m_model->setUpgradeUploadSpeedLimitConfig(uploadSpeedLimitConfig.toJson().toUtf8(), false);
     });
 }
 

--- a/src/dcc-update-plugin/operation/updatework.h
+++ b/src/dcc-update-plugin/operation/updatework.h
@@ -110,7 +110,6 @@ public:
     void setRemovePackageJob(const QString& jobPath);
     QString getServiceUrlByRegion();
     void refreshUpgradeDeliveryInfo();
-    QString transferDeliveryConfigToLastoreDeliveryConfig(const QString& deliveryConfig);
 
     Q_INVOKABLE bool openUrl(const QString& url);
     Q_INVOKABLE void onRequestRetry(int type, int updateTypes);

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -103,7 +103,8 @@ DccObject {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                text: qsTr("Failed to change Upgrade Delivery setting")
+                text: root.pendingUpgradeDeliveryEnabled ?  qsTr("Update Delivery Optimization service exception. Failed to enable.")
+                : qsTr("Update Delivery Optimization service exception. Failed to disable.")
             }
 
             Item {
@@ -122,7 +123,7 @@ DccObject {
                     focus: upgradeDeliverySetEnableFailedDialog.visible
                     onClicked: {
                         upgradeDeliverySetEnableFailedDialog.close()
-                        dccData.work().setUpgradeDeliveryEnabled(!root.pendingUpgradeDeliveryEnabled, true)
+                        dccData.work().setUpgradeDeliveryEnabled(root.pendingUpgradeDeliveryEnabled, true)
                     }
                 }
 
@@ -335,7 +336,7 @@ DccObject {
                 name: "upgradeDeliverySwitch"
                 parentName: "upgradeDeliveryGrp"
                 displayName: qsTr("Upgrade Delivery")
-                description: qsTr("Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart")
+                description: qsTr("When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.")
                 weight: 10
                 enabled: !dccData.model().updateProhibited
                 pageType: DccObject.Editor
@@ -361,6 +362,7 @@ DccObject {
             }
 
             DccObject {
+                id: upgradeDeliveryUploadLimitSetting
                 name: "upgradeDeliveryUploadLimitSetting"
                 parentName: "upgradeDeliveryGrp"
                 displayName: qsTr("Upgrade Delivery Upload Limit Setting")
@@ -368,6 +370,12 @@ DccObject {
                 weight: 20
                 enabled: !dccData.model().upgradeUploadSpeedIsOnline
                 pageType: DccObject.Item
+                Connections {
+                    target: dccData.model()
+                    function onUpgradeUploadSpeedLimitConfigChanged() {
+                        upgradeDeliveryUploadLimitSetting.enabled = !dccData.model().upgradeUploadSpeedIsOnline
+                    }
+                }
                 page: RowLayout {
                     D.CheckBox {
                         id: limitCheckBox
@@ -454,6 +462,7 @@ DccObject {
             }
 
             DccObject {
+                id: upgradeDeliveryDownloadLimitSetting
                 name: "upgradeDeliveryDownloadLimitSetting"
                 parentName: "upgradeDeliveryGrp"
                 displayName: qsTr("Upgrade Delivery Download Limit Setting")
@@ -461,6 +470,12 @@ DccObject {
                 weight: 20
                 enabled: !dccData.model().upgradeDownloadSpeedIsOnline
                 pageType: DccObject.Item
+                Connections {
+                    target: dccData.model()
+                    function onUpgradeDownloadSpeedLimitConfigChanged() {
+                        upgradeDeliveryDownloadLimitSetting.enabled = !dccData.model().upgradeDownloadSpeedIsOnline
+                    }
+                }
                 page: RowLayout {
                     D.CheckBox {
                         id: limitCheckBox
@@ -591,7 +606,7 @@ DccObject {
                 page: RowLayout {
                     D.LineEdit {
                         id: lineEdit
-                        maximumLength: 5
+                        maximumLength: 6
                         validator: RegularExpressionValidator { regularExpression: /^\d*$/ }
                         alertText: qsTr("Only numbers between 10-999999 are allowed")
                         alertDuration: 3000

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -447,7 +447,7 @@
         <translation>传递优化</translation>
     </message>
     <message>
-        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <source>When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.</source>
         <translation>开启此功能，你的设备可能会将以前下载的部分系统更新发送到本地网络的设备上。关闭此功能后，将在重启时清除传递优化时缓存的文件</translation>
     </message>
     <message>
@@ -532,11 +532,19 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新传递优化服务异常，设置失败</translation>
+        <translation>更新传递优化服务异常</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to enable.</source>
+        <translation>更新传递优化服务异常,开启失败</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to disable.</source>
+        <translation>更新传递优化服务异常,关闭失败</translation>
     </message>
     <message>
         <source>Retry</source>
-        <translation>重试</translation>
+        <translation>再试一次</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -444,19 +444,19 @@
     </message>
     <message>
         <source>Upgrade Delivery</source>
-        <translation>更新傳遞</translation>
+        <translation>傳遞優化</translation>
     </message>
     <message>
-        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <source>When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.</source>
         <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本地網絡的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
     </message>
     <message>
         <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>更新傳遞-下載限速</translation>
+        <translation>下載限速</translation>
     </message>
     <message>
         <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>更新傳遞-上傳限速</translation>
+        <translation>上傳限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -528,11 +528,19 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新傳遞優化服務異常，設置失敗</translation>
+        <translation>更新傳遞優化服務異常</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to enable.</source>
+        <translation>更新傳遞優化服務異常,開啓失敗</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to disable.</source>
+        <translation>更新傳遞優化服務異常,關閉失敗</translation>
     </message>
     <message>
         <source>Retry</source>
-        <translation>重試</translation>
+        <translation>再試一次</translation>
     </message>
     <message>
         <source>OK</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -444,19 +444,19 @@
     </message>
     <message>
         <source>Upgrade Delivery</source>
-        <translation>更新傳遞</translation>
+        <translation>傳遞優化</translation>
     </message>
     <message>
-        <source>Turning this on may cause your device to send previously downloaded system updates to devices on the local network. Turning this off will clear files cached for update delivery on restart</source>
+        <source>When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.</source>
         <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本機網路的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
     </message>
     <message>
         <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>更新傳遞-下載限速</translation>
+        <translation>下載限速</translation>
     </message>
     <message>
         <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>更新傳遞-上傳限速</translation>
+        <translation>上傳限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -528,11 +528,19 @@
     </message>
     <message>
         <source>Failed to change Upgrade Delivery setting</source>
-        <translation>更新傳遞優化服務異常，設置失敗</translation>
+        <translation>更新傳遞優化服務異常</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to enable.</source>
+        <translation>更新傳遞優化服務異常,開啟失敗</translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception. Failed to disable.</source>
+        <translation>更新傳遞優化服務異常,關閉失敗</translation>
     </message>
     <message>
         <source>Retry</source>
-        <translation>重試</translation>
+        <translation>再試一次</translation>
     </message>
     <message>
         <source>OK</source>


### PR DESCRIPTION
https://pms.uniontech.com/bug-view-357761.html
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化设置项开启关闭时候，点击重试又能开启成功


https://pms.uniontech.com/bug-view-357759.html
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化子设置项设置失败弹窗提示和按钮名称与需求不一致


https://pms.uniontech.com/bug-view-357757.html
 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化设置项开启和关闭失败，出现重试弹窗，弹窗提示信息和按钮名称与需求不一致


https://pms.uniontech.com/bug-view-357713.html
 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】修改过下载限速的值，重启系统，进入更新设置页面，下载限速的值回复默认1024


https://pms.uniontech.com/bug-view-357675.html
 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】勾选传递优化两个配置项的复选框，点击两个输入框，重启控制中心，进入更新设置页面，两个输入框的值变成了104857


https://pms.uniontech.com/bug-view-357657.html
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化功能多处文案翻译与需求不一致


https://pms.uniontech.com/bug-view-357651.html
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化子配置项，英文、繁体中文名称需要和简体中文保持一致


https://pms.uniontech.com/bug-view-357649.html
 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化配置项，英文、繁体中文名称需要和简体中文保持一致


https://pms.uniontech.com/bug-view-357561.html
 【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第五轮测试】服务端下发传递优化限速配置后，客户端仍然可以编辑限速值


https://pms.uniontech.com/bug-view-357201.html
 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第四轮测试】更新设置页面，下载限速开关开启，输入框输入1234567，最大允许输入位数与需求不一致


https://pms.uniontech.com/bug-view-357171.html
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第四轮测试】更新设置页面，下载限速开关开启，重启后下载限速开关是关闭状态


https://pms.uniontech.com/bug-view-356935.html
 【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第四轮测试】设置忙时限速未生效


https://pms.uniontech.com/bug-view-354863.html
 【V25 2500U1】【更新管理系统】【公网更新平台】【第一轮测试】终端当前基线版本号为2522，目标基线版本号为2551，控制中心未正常显示基线日志



https://pms.uniontech.com/bug-view-354303.html
 【V25 2500U1】【更新管理系统】【公网更新平台】【第一轮测试】社区版跨版本更新时，未显示中间所有的版本更新日志，只显示目标基线更新日志