### PR TITLE
fix: 私有化更新&更新传递&http限速在线配置功能第四轮bug修复-追加提交

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -214,8 +214,7 @@ bool UpdateDBusProxy::p2PUpdateEnable()
 
 bool UpdateDBusProxy::p2PUpdateSupport()
 {
-    return true;
-    // return qvariant_cast<bool>(m_updateInter->property("P2PUpdateSupport"));
+    return qvariant_cast<bool>(m_updateInter->property("P2PUpdateSupport"));
 }
 
 bool UpdateDBusProxy::immutableAutoRecovery()

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -91,6 +91,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(bool upgradeDownloadSpeedIsOnline READ upgradeDownloadSpeedIsOnline NOTIFY upgradeDownloadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString upgradeUploadSpeedCurrentRate READ upgradeUploadSpeedCurrentRate NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(QString upgradeUploadSpeedLimitRate READ upgradeUploadSpeedLimitRate NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
+    Q_PROPERTY(bool upgradeUploadSpeedIsOnline READ upgradeUploadSpeedIsOnline NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeUploadSpeedEnable READ upgradeUploadSpeedEnable NOTIFY upgradeUploadSpeedLimitConfigChanged FINAL)
     Q_PROPERTY(bool upgradeDeliveryEnable READ upgradeDeliveryEnable NOTIFY upgradeDeliveryEnableChanged FINAL)
     Q_PROPERTY(bool p2pUpdateEnabled READ isP2PUpdateEnabled NOTIFY p2pUpdateEnableStateChanged FINAL)


### PR DESCRIPTION
修复以下问题：
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化设置项开启关闭时候，点击重试又能开启成功 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化子设置项设置失败弹窗提示和按钮名称与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化设置项开启和关闭失败，出现重试弹窗，弹窗提示信息和按钮名称与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】修改过下载限速的值，重启系统，进入更新设置页面，下载限速的值回复默认1024 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】勾选传递优化两个配置项的复选框，点击两个输入框，重启控制中心，进入更新设置页面，两个输入框的值变成了104857 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化功能多处文案翻译与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化子配置项，英文、繁体中文名称需要和简体中文保持一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第五轮测试】传递优化配置项，英文、繁体中文名称需要和简体中文保持一致 【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第五轮测试】服务端下发传递优化限速配置后，客户端仍然可以编辑限速值 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第四轮测试】更新设置页面，下载限速开关开启，输入框输入1234567，最大允许输入位数与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第四轮测试】更新设置页面，下载限速开关开启，重启后下载限速开关是关闭状态 【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第四轮测试】设置忙时限速未生效
【V25 2500U1】【更新管理系统】【公网更新平台】【第一轮测试】终端当前基线版本号为2522，目标基线版本号为2551，控制中心未正常显示基线日志 【V25 2500U1】【更新管理系统】【公网更新平台】【第一轮测试】社区版跨版本更新时，未显示中间所有的版本更新日志，只显示目标基线更新日志

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-357761.html https://pms.uniontech.com/bug-view-357759.html
https://pms.uniontech.com/bug-view-357757.html
https://pms.uniontech.com/bug-view-357713.html
https://pms.uniontech.com/bug-view-357675.html
https://pms.uniontech.com/bug-view-357657.html
https://pms.uniontech.com/bug-view-357651.html
https://pms.uniontech.com/bug-view-357649.html
https://pms.uniontech.com/bug-view-357561.html
https://pms.uniontech.com/bug-view-357201.html
https://pms.uniontech.com/bug-view-357171.html
https://pms.uniontech.com/bug-view-356935.html
https://pms.uniontech.com/bug-view-354863.html
https://pms.uniontech.com/bug-view-354303.html
Influence：影响私有化更新&更新传递&http限速在线配置功能