### PR TITLE
fix(qml): fix button layout margin by adding right margin

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -135,6 +135,7 @@ DccObject {
                     hoveredDark: hovered
                 }
                 bottomPadding: 0
+                Layout.rightMargin: 8
                 font: D.DTK.fontManager.t8
                 text: advancedSetting.showDetails ? qsTr("Collapse") : qsTr("Expand")
                 onClicked: {


### PR DESCRIPTION
Add Layout.rightMargin: 8 to expand/collapse button for proper spacing.

为展开/折叠按钮添加 Layout.rightMargin: 8 以调整布局间距。

Log: 修复按钮布局边距
PMS: BUG-353875
Influence: 修复后按钮布局间距更合理，提升用户界面美观度和用户体验。