### PR TITLE
fix: Fifth round of bug fixes for private update & update transfer & …

### DIFF
--- a/src/dcc-update-plugin/operation/updatedatastructs.h
+++ b/src/dcc-update-plugin/operation/updatedatastructs.h
@@ -316,7 +316,11 @@ inline QString transferDeliveryConfigToLastoreDeliveryConfig(const QString& deli
     LastoreUpgradeSpeedLimitConfig lastoreDeliveryConfig;
     lastoreDeliveryConfig.isOnlineSpeedLimit = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).ifInOnlineLimit();
     lastoreDeliveryConfig.speedLimitEnabled = UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).shouldLimitRate();
-    lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).currentRate);
+    if (lastoreDeliveryConfig.isOnlineSpeedLimit) {
+        lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).currentRate);
+    } else {
+        lastoreDeliveryConfig.limitSpeed = QString::number(UpgradeSpeedLimitConfig::fromJson(deliveryConfig.toUtf8()).limitRate);
+    } 
     return lastoreDeliveryConfig.toJson();
 }
 

--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -14,7 +14,6 @@ import org.deepin.dcc.update 1.0
 DccObject {
     id: root
     property bool syncingUpgradeDeliverySwitch: false
-    property bool pendingUpgradeDeliveryEnabled: dccData.model().upgradeDeliveryEnable
 
     FontMetrics {
         id: fm
@@ -34,7 +33,7 @@ DccObject {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                text: qsTr("Failed to change Upgrade Delivery setting")
+                text: qsTr("Failed to change Delivery Optimization setting")
             }
 
             Item {
@@ -48,10 +47,13 @@ DccObject {
                 spacing: 10
 
                 ButtonWithToolTip {
-                    text: qsTr("OK")
+                    text: qsTr("Cancel")
                     Layout.fillWidth: true
                     focus: upgradeDeliverySetConfigFailedDialog.visible
                     onClicked: {
+                        upgradeDeliverySetConfigFailedDialog.close()
+                    }
+                    Keys.onEscapePressed: {
                         upgradeDeliverySetConfigFailedDialog.close()
                     }
                 }
@@ -103,8 +105,7 @@ DccObject {
                 Layout.fillWidth: true
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
-                text: root.pendingUpgradeDeliveryEnabled ?  qsTr("Update Delivery Optimization service exception. Failed to enable.")
-                : qsTr("Update Delivery Optimization service exception. Failed to disable.")
+                text: qsTr("Update Delivery Optimization service exception")
             }
 
             Item {
@@ -123,12 +124,15 @@ DccObject {
                     focus: upgradeDeliverySetEnableFailedDialog.visible
                     onClicked: {
                         upgradeDeliverySetEnableFailedDialog.close()
-                        dccData.work().setUpgradeDeliveryEnabled(root.pendingUpgradeDeliveryEnabled, true)
+                        dccData.work().setUpgradeDeliveryEnabled(!dccData.model().upgradeDeliveryEnable, true)
+                    }
+                    Keys.onEscapePressed: {
+                        upgradeDeliverySetEnableFailedDialog.close()
                     }
                 }
 
                 EnableFailedDialogButton {
-                    text: qsTr("OK")
+                    text: qsTr("Cancel")
                     Layout.fillWidth: true
                     onClicked: {
                         upgradeDeliverySetEnableFailedDialog.close()
@@ -173,6 +177,7 @@ DccObject {
         parentName: "updateSettingsPage"
         displayName: qsTr("Update Type")
         weight: 10
+        visible: !dccData.model().isPrivateUpdate
     }
 
     DccObject {
@@ -181,6 +186,7 @@ DccObject {
         parentName: "updateSettingsPage"
         weight: 20
         pageType: DccObject.Item
+        visible: !dccData.model().isPrivateUpdate
         page: DccGroupView {
             height: implicitHeight + 10
             spacing: 0
@@ -245,7 +251,7 @@ DccObject {
 
     DccObject {
         id: advancedSetting
-        property bool showDetails: false
+        property bool showDetails: dccData.model().isPrivateUpdate
         name: "advancedSettingTitle"
         parentName: "updateSettingsPage"
         displayName: qsTr("Advanced Settings")
@@ -253,7 +259,7 @@ DccObject {
         pageType: DccObject.Item
         page: RowLayout {
             Component.onDestruction:   {
-                advancedSetting.showDetails = false
+                advancedSetting.showDetails = false || dccData.model().isPrivateUpdate
             }
             DccLabel {
                 property D.Palette textColor: D.Palette {
@@ -335,10 +341,10 @@ DccObject {
             DccObject {
                 name: "upgradeDeliverySwitch"
                 parentName: "upgradeDeliveryGrp"
-                displayName: qsTr("Upgrade Delivery")
+                displayName: qsTr("Delivery Optimization")
                 description: qsTr("When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.")
                 weight: 10
-                enabled: !dccData.model().updateProhibited
+                enabled: !dccData.model().isPrivateUpdate
                 pageType: DccObject.Editor
                 page: D.Switch {
                     id: upgradeDeliverySwitch
@@ -347,7 +353,6 @@ DccObject {
                         if (root.syncingUpgradeDeliverySwitch) {
                             return
                         }
-                        root.pendingUpgradeDeliveryEnabled = checked
                         dccData.work().setUpgradeDeliveryEnabled(checked)
                     }
                     Connections {
@@ -365,7 +370,7 @@ DccObject {
                 id: upgradeDeliveryUploadLimitSetting
                 name: "upgradeDeliveryUploadLimitSetting"
                 parentName: "upgradeDeliveryGrp"
-                displayName: qsTr("Upgrade Delivery Upload Limit Setting")
+                displayName: qsTr("Delivery Optimization-Upload throttling")
                 visible: dccData.model().upgradeDeliveryEnable
                 weight: 20
                 enabled: !dccData.model().upgradeUploadSpeedIsOnline
@@ -465,9 +470,9 @@ DccObject {
                 id: upgradeDeliveryDownloadLimitSetting
                 name: "upgradeDeliveryDownloadLimitSetting"
                 parentName: "upgradeDeliveryGrp"
-                displayName: qsTr("Upgrade Delivery Download Limit Setting")
+                displayName: qsTr("Delivery Optimization-Limit Speed")
                 visible: dccData.model().upgradeDeliveryEnable
-                weight: 20
+                weight: 30
                 enabled: !dccData.model().upgradeDownloadSpeedIsOnline
                 pageType: DccObject.Item
                 Connections {
@@ -566,7 +571,7 @@ DccObject {
             id: downloadLimitGrp
             name: "downloadLimitGrp"
             parentName: "advancedSettingGroup"
-            weight: 40
+            weight: 50
             enabled: !dccData.model().downloadIsOnlineSpeedLimit
             pageType: DccObject.Item
             page: DccGroupView {

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -423,6 +423,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delivery Optimization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delivery Optimization-Limit Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delivery Optimization-Upload throttling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Limit Speed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -492,6 +508,22 @@
     </message>
     <message>
         <source>Only numbers between 10-999999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to change Delivery Optimization setting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -423,6 +423,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Delivery Optimization</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delivery Optimization-Limit Speed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delivery Optimization-Upload throttling</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Limit Speed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -488,6 +504,26 @@
     </message>
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only numbers between 10-999999 are allowed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to change Delivery Optimization setting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Delivery Optimization service exception</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Retry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -443,7 +443,7 @@
         <translation>提供额外添加的仓库源更新内容</translation>
     </message>
     <message>
-        <source>Upgrade Delivery</source>
+        <source>Delivery Optimization</source>
         <translation>传递优化</translation>
     </message>
     <message>
@@ -451,12 +451,12 @@
         <translation>开启此功能，你的设备可能会将以前下载的部分系统更新发送到本地网络的设备上。关闭此功能后，将在重启时清除传递优化时缓存的文件</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>下载限速</translation>
+        <source>Delivery Optimization-Limit Speed</source>
+        <translation>传递优化-下载限速</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>上传限速</translation>
+        <source>Delivery Optimization-Upload throttling</source>
+        <translation>传递优化-上传限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -531,24 +531,20 @@
         <translation>只允许输入10-999999</translation>
     </message>
     <message>
-        <source>Failed to change Upgrade Delivery setting</source>
+        <source>Failed to change Delivery Optimization setting</source>
         <translation>更新传递优化服务异常</translation>
     </message>
     <message>
-        <source>Update Delivery Optimization service exception. Failed to enable.</source>
-        <translation>更新传递优化服务异常,开启失败</translation>
-    </message>
-    <message>
-        <source>Update Delivery Optimization service exception. Failed to disable.</source>
-        <translation>更新传递优化服务异常,关闭失败</translation>
+        <source>Update Delivery Optimization service exception</source>
+        <translation>更新传递优化服务异常</translation>
     </message>
     <message>
         <source>Retry</source>
         <translation>再试一次</translation>
     </message>
     <message>
-        <source>OK</source>
-        <translation>确定</translation>
+        <source>Cancel</source>
+        <translation>取消</translation>
     </message>
     <message>
         <source>Join the internal testing channel to get deepin latest updates.</source>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -443,7 +443,7 @@
         <translation>提供額外添加的倉庫源更新內容</translation>
     </message>
     <message>
-        <source>Upgrade Delivery</source>
+        <source>Delivery Optimization</source>
         <translation>傳遞優化</translation>
     </message>
     <message>
@@ -451,12 +451,12 @@
         <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本地網絡的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>下載限速</translation>
+        <source>Delivery Optimization-Limit Speed</source>
+        <translation>傳遞優化-下載限速</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>上傳限速</translation>
+        <source>Delivery Optimization-Upload throttling</source>
+        <translation>傳遞優化-上傳限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -527,24 +527,20 @@
         <translation>只允許輸入1-99999</translation>
     </message>
     <message>
-        <source>Failed to change Upgrade Delivery setting</source>
+        <source>Failed to change Delivery Optimization setting</source>
         <translation>更新傳遞優化服務異常</translation>
     </message>
     <message>
-        <source>Update Delivery Optimization service exception. Failed to enable.</source>
-        <translation>更新傳遞優化服務異常,開啓失敗</translation>
-    </message>
-    <message>
-        <source>Update Delivery Optimization service exception. Failed to disable.</source>
-        <translation>更新傳遞優化服務異常,關閉失敗</translation>
+        <source>Update Delivery Optimization service exception</source>
+        <translation>更新傳遞優化服務異常</translation>
     </message>
     <message>
         <source>Retry</source>
         <translation>再試一次</translation>
     </message>
     <message>
-        <source>OK</source>
-        <translation>確定</translation>
+        <source>Cancel</source>
+        <translation>取消</translation>
     </message>
     <message>
         <source>Join the internal testing channel to get deepin latest updates.</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -443,7 +443,7 @@
         <translation>提供額外新增的倉庫源更新內容</translation>
     </message>
     <message>
-        <source>Upgrade Delivery</source>
+        <source>Delivery Optimization</source>
         <translation>傳遞優化</translation>
     </message>
     <message>
@@ -451,12 +451,12 @@
         <translation>開啟此功能，你的裝置可能會將以前下載的部分系統更新傳送到本機網路的裝置上。關閉此功能後，將在重新啟動時清除更新傳遞時快取的檔案</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Download Limit Setting</source>
-        <translation>下載限速</translation>
+        <source>Delivery Optimization-Limit Speed</source>
+        <translation>傳遞優化-下載限速</translation>
     </message>
     <message>
-        <source>Upgrade Delivery Upload Limit Setting</source>
-        <translation>上傳限速</translation>
+        <source>Delivery Optimization-Upload throttling</source>
+        <translation>傳遞優化-上傳限速</translation>
     </message>
     <message>
         <source>Limit Speed</source>
@@ -527,24 +527,20 @@
         <translation>只允許輸入1-99999</translation>
     </message>
     <message>
-        <source>Failed to change Upgrade Delivery setting</source>
+        <source>Failed to change Delivery Optimization setting</source>
         <translation>更新傳遞優化服務異常</translation>
     </message>
     <message>
-        <source>Update Delivery Optimization service exception. Failed to enable.</source>
-        <translation>更新傳遞優化服務異常,開啟失敗</translation>
-    </message>
-    <message>
-        <source>Update Delivery Optimization service exception. Failed to disable.</source>
-        <translation>更新傳遞優化服務異常,關閉失敗</translation>
+        <source>Update Delivery Optimization service exception</source>
+        <translation>更新傳遞優化服務異常</translation>
     </message>
     <message>
         <source>Retry</source>
         <translation>再試一次</translation>
     </message>
     <message>
-        <source>OK</source>
-        <translation>確定</translation>
+        <source>Cancel</source>
+        <translation>取消</translation>
     </message>
     <message>
         <source>Join the internal testing channel to get deepin latest updates.</source>

--- a/src/dock-update-plugin/pluginupdateplugin.cpp
+++ b/src/dock-update-plugin/pluginupdateplugin.cpp
@@ -40,6 +40,7 @@ PluginUpdatePlugin::PluginUpdatePlugin(QObject *parent)
     , m_currentState(UpdateState::UpdatesAvailable)
     , m_updateMode(0)
     , m_shouldShow(false)
+    , m_isPrivateUpdate(false)
 {
     m_tipsLabel->setVisible(false);
     m_tipsLabel->setAccessibleName("plugin-update");
@@ -239,7 +240,7 @@ void PluginUpdatePlugin::loadPlugin()
 
 void PluginUpdatePlugin::refreshPluginItemsVisible()
 {
-    bool shouldShow = !pluginIsDisable() && m_shouldShow;
+    bool shouldShow = !pluginIsDisable() && m_shouldShow && !m_isPrivateUpdate;
 
     if (!shouldShow) {
         if (m_pluginLoaded) {
@@ -288,6 +289,8 @@ void PluginUpdatePlugin::onConfigChanged(const QString &key)
     } else if (key == "update-status") {
         m_updateStatus = m_dconfig->value("update-status", QVariant());
         qCInfo(dockUpdatePlugin) << "UpdateStatus changed to:" << m_updateStatus;
+    } else if (key == "intranet-update") {
+        m_isPrivateUpdate = m_dconfig->value("intranet-update", false).toBool();
     }
     //对dconfig获取的数据进行解析，从而处理更新的状态和是否显示
     updateStateFromUpdateStatus();

--- a/src/dock-update-plugin/pluginupdateplugin.h
+++ b/src/dock-update-plugin/pluginupdateplugin.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,6 +76,7 @@ private:
     int m_updateMode;
     QVariant m_updateStatus;
     bool m_shouldShow;
+    bool m_isPrivateUpdate;
 };
 
 Q_DECLARE_METATYPE(UpdateState)


### PR DESCRIPTION
…HTTP speed limit online configuration features

Fixed the following issues:
[V25 2500U1][Update Management System][Enterprise Update Management System][Sixth Round Testing] When the server supports P2P and the terminal successfully connects, the transfer optimization switch in Control Center should be grayed out and non-closable [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][Public Network] After checking the upload speed limit and download speed limit checkboxes of transfer optimization sub-items, unchecking them again causes the speed limit value to change to 104857 [V25 2500U1][Update Management System][Control Center Update Client][Fourth Round Testing] After modifying the status or value of transfer optimization upload/download speed limits, reopening Control Center causes the transfer optimization upload/download speed limit positions to change [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][Public Network] The English translation of transfer optimization does not match requirements [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][System Update][Public Network] When enabling or disabling transfer optimization settings fails, a retry dialog appears with prompt information and buttons inconsistent with requirements [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][Public Network] When enabling or disabling transfer optimization sub-item settings fails, the dialog display does not match requirements [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][Public Network] When enabling transfer optimization settings fails, the dialog needs to support closing with Esc key [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][Public Network] When enabling or disabling transfer optimization sub-item settings fails, the dialog needs to support closing with Esc key [V25 2500U1][Update Management System][Control Center Update Client][Sixth Round Testing][System Update][Public Network] The display names of transfer optimization sub-items need to match requirements

Log: As above
Bug: https://pms.uniontech.com/bug-view-357875.html https://pms.uniontech.com/bug-view-358203.html
https://pms.uniontech.com/bug-view-357291.html
https://pms.uniontech.com/bug-view-358231.html
https://pms.uniontech.com/bug-view-358257.html
https://pms.uniontech.com/bug-view-358321.html
https://pms.uniontech.com/bug-view-358303.html
https://pms.uniontech.com/bug-view-358357.html
https://pms.uniontech.com/bug-view-358365.html
Influence: Affects private update & update transfer & HTTP speed limit online configuration features

fix: 私有化更新&更新传递&http限速在线配置功能第五轮bug修复
修复以下问题：
【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第六轮测试】服务端支持P2P，终端接入成功后，控制中心-传递优化开关应该置灰并不可关闭 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【公网】勾选传递优化子配置项的上传限速和下载限速复选框，再次去勾选复选框，限速值变成了104857 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第四轮测试】修改传递优化上传下载限速的状态或者值，重新打开控制中心，传递优化上传下载限速位置发生变化 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【公网】传递优化英文翻译与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【系统更新】【公网】传递优化设置项开启或关闭失败，出现重试弹窗，提示信息和按钮与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【公网】传递优化设置项子配置项开启或关闭失败，弹窗展示与需求不一致 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【公网】传递优化设置项开启失败，弹窗需要支持Esc键关闭弹窗 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【公网】传递优化设置项子配置项开启或关闭失败，弹窗需要支持esc关闭操作 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第六轮测试】【系统更新】【公网】传递优化子配置项展示名称需要与需求一致

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-357875.html https://pms.uniontech.com/bug-view-358203.html
https://pms.uniontech.com/bug-view-357291.html
https://pms.uniontech.com/bug-view-358231.html
https://pms.uniontech.com/bug-view-358257.html
https://pms.uniontech.com/bug-view-358321.html
https://pms.uniontech.com/bug-view-358303.html
https://pms.uniontech.com/bug-view-358357.html
https://pms.uniontech.com/bug-view-358365.html
Influence：影响私有化更新&更新传递&http限速在线配置功能