### PR TITLE
fix: 私有化更新&更新传递&http限速在线配置功能第六轮bug修复

### DIFF
--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -207,6 +207,11 @@ QString UpdateDBusProxy::updateStatus()
     return qvariant_cast<QString>(m_managerInter->property("UpdateStatus"));
 }
 
+bool UpdateDBusProxy::downloadLimitOnChanging()
+{
+    return qvariant_cast<bool>(m_managerInter->property("downloadLimitOnChanging"));
+}
+
 bool UpdateDBusProxy::p2PUpdateEnable()
 {
     return qvariant_cast<bool>(m_updateInter->property("P2PUpdateEnable"));

--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -67,6 +67,9 @@ public:
     Q_PROPERTY(QString updateStatus  READ updateStatus NOTIFY UpdateStatusChanged)
     QString updateStatus();
 
+    Q_PROPERTY(bool downloadLimitOnChanging  READ downloadLimitOnChanging NOTIFY DownloadLimitOnChangingChanged)
+    bool downloadLimitOnChanging();
+
     Q_PROPERTY(bool ImmutableAutoRecovery READ immutableAutoRecovery NOTIFY ImmutableAutoRecoveryChanged)
     bool immutableAutoRecovery();
 
@@ -156,6 +159,7 @@ signals:
     void AutoCleanChanged(bool value) const;
     void UpdateModeChanged(qulonglong value) const;
     void UpdateStatusChanged(QString value) const;
+    void DownloadLimitOnChangingChanged(bool value) const;
     void ImmutableAutoRecoveryChanged(bool value) const;
     void P2PUpdateEnableChanged(bool value) const;
     void P2PUpdateSupportChanged(bool value) const;

--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -67,7 +67,7 @@ UpdateModel::UpdateModel(QObject* parent)
     , m_downloadWaiting(false)
     , m_downloadPaused(false)
     , m_upgradeWaiting(false)
-    , m_scheduledUpgradeTime("")
+    , m_forceUpdateText("")
     , m_downloadProgress(0.0)
     , m_distUpgradeProgress(0.0)
     , m_backupProgress(0.0)
@@ -221,22 +221,25 @@ void UpdateModel::setBatterIsOK(bool ok)
     Q_EMIT batterIsOKChanged(ok);
 }
 
-void UpdateModel::setScheduledUpgradeTime()
+void UpdateModel::setForceUpdateText(const QString& updateTime, int lastoreStatus)
 {
-    QString updateTime = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "","update-time", "").toString();
     if (!updateTime.isEmpty()) {
         QDateTime dateTime = QDateTime::fromString(updateTime, Qt::ISODate);
         if (dateTime.isValid()) {
             QString formattedDateTime = dateTime.toString("HH:mm:ss");
             qCDebug(logDccUpdatePlugin) << "Set scheduled upgrade time:" << formattedDateTime;
-            if (m_scheduledUpgradeTime == formattedDateTime) {
+            if (m_forceUpdateText == formattedDateTime) {
                 return;
             }
 
-            m_scheduledUpgradeTime = formattedDateTime;
-            Q_EMIT scheduledUpgradeTimeChanged();
+            m_forceUpdateText = tr("will upgrade at %1").arg(formattedDateTime);
         }
+    } else if (lastoreStatus == ShutdownUpdateStatus) {
+        m_forceUpdateText = tr("will upgrade when shutdown");
+    } else {
+        m_forceUpdateText = "";
     }
+    Q_EMIT forceUpdateTextChanged();
 }
 
 void UpdateModel::setLastStatus(const UpdatesStatus& status, int line, int types)

--- a/src/dcc-update-plugin/operation/updatemodel.h
+++ b/src/dcc-update-plugin/operation/updatemodel.h
@@ -55,7 +55,7 @@ class UpdateModel : public QObject
     Q_PROPERTY(bool downloadWaiting READ downloadWaiting NOTIFY downloadWaitingChanged FINAL)
     Q_PROPERTY(bool downloadPaused READ downloadPaused NOTIFY downloadPausedChanged FINAL)
     Q_PROPERTY(bool upgradeWaiting READ upgradeWaiting NOTIFY upgradeWaitingChanged FINAL)
-    Q_PROPERTY(QString scheduledUpgradeTime READ scheduledUpgradeTime NOTIFY scheduledUpgradeTimeChanged FINAL)
+    Q_PROPERTY(QString forceUpdateText READ forceUpdateText NOTIFY forceUpdateTextChanged FINAL)
 
     Q_PROPERTY(double downloadProgress READ downloadProgress NOTIFY downloadProgressChanged FINAL)
     Q_PROPERTY(double backupProgress READ backupProgress NOTIFY backupProgressChanged FINAL)
@@ -200,8 +200,8 @@ public:
     bool upgradeWaiting() const { return m_upgradeWaiting; }
     void setUpgradeWaiting(bool waiting);
 
-    QString scheduledUpgradeTime() const { return m_scheduledUpgradeTime; }
-    void setScheduledUpgradeTime();
+    QString forceUpdateText() const { return m_forceUpdateText; }
+    void setForceUpdateText(const QString& updateTime, int lastoreStatus);
 
     double downloadProgress() const { return m_downloadProgress; }
     void setDownloadProgress(double downloadProgress);
@@ -401,7 +401,7 @@ Q_SIGNALS:
     void downloadWaitingChanged(bool waiting);
     void downloadPausedChanged(bool paused);
     void upgradeWaitingChanged(bool waiting);
-    void scheduledUpgradeTimeChanged();
+    void forceUpdateTextChanged();
 
     void downloadProgressChanged(const double &progress);
     void backupProgressChanged(double progress);
@@ -481,7 +481,7 @@ private:
     bool m_downloadWaiting;
     bool m_downloadPaused;
     bool m_upgradeWaiting;
-    QString m_scheduledUpgradeTime;
+    QString m_forceUpdateText;
     double m_downloadProgress;
     double m_distUpgradeProgress;
     double m_backupProgress;

--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -299,7 +299,7 @@ void UpdateWorker::initConfig()
     qCDebug(logDccUpdatePlugin) << "Initialize lastore daemon configuration";
     if (m_lastoreDConfig && m_lastoreDConfig->isValid()) {
         m_model->setLastoreDaemonStatus(m_lastoreDConfig->value("lastore-daemon-status").toInt());
-        m_model->setScheduledUpgradeTime();
+        m_model->setForceUpdateText(m_lastoreDConfig->value("update-time").toString(), m_lastoreDConfig->value("lastore-daemon-status").toInt());
         connect(m_lastoreDConfig, &DConfig::valueChanged, this, [this](const QString& key) {
             if ("lastore-daemon-status" == key) {
                 bool ok;
@@ -310,8 +310,8 @@ void UpdateWorker::initConfig()
                 }
                 m_model->setForceUpdate();
             }
-            if ("update-time" == key) {
-                m_model->setScheduledUpgradeTime();
+            if ("update-time" == key || "lastore-daemon-status" == key) {
+                m_model->setForceUpdateText(m_lastoreDConfig->value("update-time").toString(), m_lastoreDConfig->value("lastore-daemon-status").toInt());
                 m_model->setForceUpdate();
             }
         });
@@ -1785,7 +1785,7 @@ void UpdateWorker::setUpgradeDeliveryDownloadLimitSpeed(const QString& speed, bo
         watcher->deleteLater();
         if (watcher->isError()) {
             qCWarning(logDccUpdatePlugin) << "Set upgrade download speed limit config error: " << watcher->error().message();
-            getUpgradeDeliveryDownloadLimitSpeed();
+            m_model->setUpgradeDownloadSpeedLimitConfig(m_model->upgradeDownloadSpeedLimitConfig().toJson().toUtf8());
             Q_EMIT upgradeDeliveryConfigSetFailed();
             return;
         }
@@ -1805,7 +1805,7 @@ void UpdateWorker::setUpgradeDeliveryUploadLimitSpeed(const QString& speed, bool
         watcher->deleteLater();
         if (watcher->isError()) {
             qCWarning(logDccUpdatePlugin) << "Set upgrade upload speed limit config error: " << watcher->error().message();
-            getUpgradeDeliveryUploadLimitSpeed();
+            m_model->setUpgradeUploadSpeedLimitConfig(m_model->upgradeUploadSpeedLimitConfig().toJson().toUtf8());
             Q_EMIT upgradeDeliveryConfigSetFailed();
             return;
         }

--- a/src/dcc-update-plugin/qml/UpdateMain.qml
+++ b/src/dcc-update-plugin/qml/UpdateMain.qml
@@ -297,9 +297,7 @@ DccObject {
                 qsTr("Check Again")
             ] : [qsTr("Install updates")]
             function updateSecondaryTips() {
-                secondaryUpdateTips = dccData.model().scheduledUpgradeTime.length !== 0
-                    ? qsTr("will upgrade at %1").arg(dccData.model().scheduledUpgradeTime)
-                    : ""
+                secondaryUpdateTips = dccData.model().forceUpdateText
             }
             updateTips: {
                 if (!dccData.model().batterIsOK) {
@@ -346,7 +344,7 @@ DccObject {
 
             Connections {
                 target: dccData.model()
-                function onScheduledUpgradeTimeChanged() {
+                function onForceUpdateTextChanged() {
                     preInstallUpdateControl.updateSecondaryTips()
                 }
             }

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -206,10 +206,6 @@
         <translation>更新大小：</translation>
     </message>
     <message>
-        <source>will upgrade at %1</source>
-        <translation>将于%1开始系统更新</translation>
-    </message>
-    <message>
         <source>Downloading</source>
         <translation>下载中</translation>
     </message>
@@ -375,6 +371,14 @@
     <message>
         <source>Turn on the switches under Update Content to get better experiences</source>
         <translation>开启更新内容开关，可以获得更优质的功能体验哦</translation>
+    </message>
+    <message>
+        <source>will upgrade when shutdown</source>
+        <translation>系统将在计算机关机或重启时进行更新</translation>
+    </message>
+    <message>
+        <source>will upgrade at %1</source>
+        <translation>将于%1开始系统更新</translation>
     </message>
     <message>
         <source>Your system is not activated, and it failed to connect to update services</source>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -206,10 +206,6 @@
         <translation>更新大小：</translation>
     </message>
     <message>
-        <source>will upgrade at %1</source>
-        <translation>將於%1開始系統更新</translation>
-    </message>
-    <message>
         <source>Downloading</source>
         <translation>下載中</translation>
     </message>
@@ -377,6 +373,14 @@
         <translation>開啓更新內容開關，可以獲得更優質的功能體驗哦</translation>
     </message>
     <message>
+        <source>will upgrade when shutdown</source>
+        <translation>系統將在計算機關機或重啓時進行更新</translation>
+    </message>
+    <message>
+        <source>will upgrade at %1</source>
+        <translation>將於%1開始系統更新</translation>
+    </message>
+    <message>
         <source>Your system is not activated, and it failed to connect to update services</source>
         <translation>當前系統未激活，無法啓動更新服務</translation>
     </message>
@@ -525,6 +529,10 @@
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>只允許輸入1-99999</translation>
+    </message>
+    <message>
+        <source>Only numbers between 10-999999 are allowed</source>
+        <translation>只允許輸入10-999999</translation>
     </message>
     <message>
         <source>Failed to change Delivery Optimization setting</source>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -206,10 +206,6 @@
         <translation>更新大小：</translation>
     </message>
     <message>
-        <source>will upgrade at %1</source>
-        <translation>將於%1開始系統更新</translation>
-    </message>
-    <message>
         <source>Downloading</source>
         <translation>下載中</translation>
     </message>
@@ -377,6 +373,14 @@
         <translation>開啟更新內容開關，可以獲得更優質的功能體驗哦</translation>
     </message>
     <message>
+        <source>will upgrade when shutdown</source>
+        <translation>系統將在計算機關機或重啟時進行更新</translation>
+    </message>
+    <message>
+        <source>will upgrade at %1</source>
+        <translation>將於%1開始系統更新</translation>
+    </message>
+    <message>
         <source>Your system is not activated, and it failed to connect to update services</source>
         <translation>當前系統未啟用，無法啟動更新服務</translation>
     </message>
@@ -525,6 +529,10 @@
     <message>
         <source>Only numbers between 1-99999 are allowed</source>
         <translation>只允許輸入1-99999</translation>
+    </message>
+    <message>
+        <source>Only numbers between 10-999999 are allowed</source>
+        <translation>只允許輸入10-999999</translation>
     </message>
     <message>
         <source>Failed to change Delivery Optimization setting</source>

--- a/src/dock-update-plugin/pluginupdateplugin.cpp
+++ b/src/dock-update-plugin/pluginupdateplugin.cpp
@@ -105,6 +105,7 @@ void PluginUpdatePlugin::init(PluginProxyInterface *proxyInter)
 
     m_updateMode = m_dconfig->value("update-mode").toInt();
     m_updateStatus = m_dconfig->value("update-status");
+    m_isPrivateUpdate = m_dconfig->value("intranet-update", false).toBool();
 
     connect(m_dconfig.data(), &DConfig::valueChanged, this, &PluginUpdatePlugin::onConfigChanged);
 

--- a/src/private-lastore-tray/tipswidget.cpp
+++ b/src/private-lastore-tray/tipswidget.cpp
@@ -20,6 +20,7 @@ TipsWidget::TipsWidget(QWidget *parent)
     m_type = TipsWidget::MultiLine;
     if (m_managerInter) {
         connect(m_managerInter, &UpdateDBusProxy::JobListChanged, this, &TipsWidget::onRefreshJobList);
+        connect(m_managerInter, &UpdateDBusProxy::DownloadLimitOnChangingChanged, this, &TipsWidget::onDownloadLimitChanged);
     }
 }
 
@@ -124,6 +125,10 @@ void TipsWidget::onSetUpdateProto(const QString& proto)
 void TipsWidget::onSetUpdateSpeed(qlonglong speed)
 {
     m_speed = speed;
+}
+
+void TipsWidget::onDownloadLimitChanged(bool value) {
+    m_downloadLimitOnChanging = value;
 }
 
 void TipsWidget::onSetUpdateProgress(double progress)

--- a/src/private-lastore-tray/tipswidget.h
+++ b/src/private-lastore-tray/tipswidget.h
@@ -82,6 +82,7 @@ private slots:
     void onSetBackUpProgress(double progress);
     void onSetUpdateProto(const QString &proto);
     void onSetUpdateSpeed(qlonglong speed);
+    void onDownloadLimitChanged(bool value);
 
 private:
     UpdateDBusProxy *m_managerInter = nullptr;

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_HK.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_HK.ts
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>PrivateLastorePlugin</name>
+    <message>
+        <source>Private Lastore</source>
+        <translation>更新獨立客戶端</translation>
+    </message>
+</context>
+<context>
+    <name>TipsWidget</name>
+    <message>
+        <source>Download complete</source>
+        <translation>更新包下載完成</translation>
+    </message>
+    <message>
+        <source>Shutdown update</source>
+        <translation>將在下次關機/重啟時開始更新</translation>
+    </message>
+    <message>
+        <source>Will upgrade at %1</source>
+        <translation>將於%1開始系統更新</translation>
+    </message>
+    <message>
+        <source>Download complete. Please open Control Center to check.</source>
+        <translation>更新包下載完成，點擊圖標進入更新界面進行查看與安裝更新</translation>
+    </message>
+    <message>
+        <source>Changing download speed limit. Please wait</source>
+        <translation>下載限速配置切換中，切換完成後將會繼續下載更新資源</translation>
+    </message>
+    <message>
+        <source>Upgrade complete. Please reboot.</source>
+        <translation>更新完成，請重啟系統</translation>
+    </message>
+    <message>
+        <source>Upgrade failed. Please check.</source>
+        <translation>更新失敗，點擊查看</translation>
+    </message>
+    <message>
+        <source>New version available. Please check.</source>
+        <translation>有新版本，點擊圖標查看</translation>
+    </message>
+    <message>
+        <source>Current upgrade progress</source>
+        <translation>更新進度</translation>
+    </message>
+    <message>
+        <source>Backing up</source>
+        <translation>備份中</translation>
+    </message>
+    <message>
+        <source>Downloading</source>
+        <translation>更新包下載中</translation>
+    </message>
+    <message>
+        <source>Current download progress</source>
+        <translation>已下載</translation>
+    </message>
+    <message>
+        <source>Current speed</source>
+        <translation>下載速度</translation>
+    </message>
+    <message>
+        <source>Installing</source>
+        <translation>系統更新中，請勿關閉計算機</translation>
+    </message>
+    <message>
+        <source>Enterprise Upgrade Management System</source>
+        <translation>企業級更新管理系統</translation>
+    </message>
+</context>
+</TS>

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_TW.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_TW.ts
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>PrivateLastorePlugin</name>
+    <message>
+        <source>Private Lastore</source>
+        <translation>更新獨立客戶端</translation>
+    </message>
+</context>
+<context>
+    <name>TipsWidget</name>
+    <message>
+        <source>Download complete</source>
+        <translation>更新包下載完成</translation>
+    </message>
+    <message>
+        <source>Shutdown update</source>
+        <translation>將在下次關機/重新啟動時開始更新</translation>
+    </message>
+    <message>
+        <source>Will upgrade at %1</source>
+        <translation>將於%1開始系統更新</translation>
+    </message>
+    <message>
+        <source>Download complete. Please open Control Center to check.</source>
+        <translation>更新包下載完成，點擊圖標進入更新介面進行查看與安裝更新</translation>
+    </message>
+    <message>
+        <source>Changing download speed limit. Please wait</source>
+        <translation>下載限速配置切換中，切換完成後將會繼續下載更新資源</translation>
+    </message>
+    <message>
+        <source>Upgrade complete. Please reboot.</source>
+        <translation>更新完成，請重新啟動系統</translation>
+    </message>
+    <message>
+        <source>Upgrade failed. Please check.</source>
+        <translation>更新失敗，點擊查看</translation>
+    </message>
+    <message>
+        <source>New version available. Please check.</source>
+        <translation>有新版本，點擊圖標查看</translation>
+    </message>
+    <message>
+        <source>Current upgrade progress</source>
+        <translation>更新進度</translation>
+    </message>
+    <message>
+        <source>Backing up</source>
+        <translation>備份中</translation>
+    </message>
+    <message>
+        <source>Downloading</source>
+        <translation>更新包下載中</translation>
+    </message>
+    <message>
+        <source>Current download progress</source>
+        <translation>已下載</translation>
+    </message>
+    <message>
+        <source>Current speed</source>
+        <translation>下載速度</translation>
+    </message>
+    <message>
+        <source>Installing</source>
+        <translation>系統更新中，請勿關閉電腦</translation>
+    </message>
+    <message>
+        <source>Enterprise Upgrade Management System</source>
+        <translation>企業級更新管理系統</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
修复以下问题：
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第七轮测试】【系统更新】【公网】传递优化设置项子配置项去勾选失败，去勾选成功了 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第七轮测试】【控制中心】【系统更新】【公网】繁体中文环境，传递优化和下载限速输入框输入非法值，提示信息是英文

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-358767.html https://pms.uniontech.com/bug-view-358703.html
Influence：影响私有化更新&更新传递&http限速在线配置功能