### PR TITLE
fix: Resolved issue where private update tray visibility could be con…

### DIFF
--- a/src/private-lastore-tray/privatelastoreplugin.cpp
+++ b/src/private-lastore-tray/privatelastoreplugin.cpp
@@ -77,6 +77,12 @@ QWidget *PrivateLastorePlugin::itemTipsWidget(const QString &itemKey)
     return m_item->tipsWidget();
 }
 
+Dock::PluginFlags PrivateLastorePlugin::flags() const
+{
+    //私有化托盘插件移除了Attribute_Normal中的Attribute_CanSetting属性，禁止用户在控制中心自行设置可见性
+    return Dock::PluginFlag::Type_System | Dock::PluginFlag::Attribute_CanDrag | Dock::PluginFlag::Attribute_CanInsert;
+}
+
 void PrivateLastorePlugin::loadPlugin()
 {
     if (m_pluginLoaded) {

--- a/src/private-lastore-tray/privatelastoreplugin.h
+++ b/src/private-lastore-tray/privatelastoreplugin.h
@@ -31,6 +31,7 @@ public:
     bool pluginIsAllowDisable() override { return true; }
     QWidget *itemWidget(const QString &itemKey) Q_DECL_OVERRIDE;
     QWidget *itemTipsWidget(const QString &itemKey) Q_DECL_OVERRIDE;
+    Dock::PluginFlags flags() const Q_DECL_OVERRIDE;
 
 private:
     void loadPlugin();


### PR DESCRIPTION
…trolled via the Control Center

Private update tray no longer allows users to manually set visibility [V25 2500U1] [Update Management System] [Enterprise Update Management System] [Round 8] After the client successfully connects to a private update source, the standalone update client option in the taskbar settings should not be deselectable [V25 2500U1] [Update Management System] [Control Center Update Client] [Round 8] [System Update] [Public Network] [Taskbar] [Update Status Plugin] For public network system updates, the "Standalone Update Client" option should not be displayed in the Control Center plugin area's update status configuration items

Log: As above
Bug:
https://pms.uniontech.com/bug-view-359261.html
https://pms.uniontech.com/bug-view-359269.html
Influence: Affects the configuration option of the private update tray in the Control Center

fix: 修复私有化托盘可见性可以通过控制中心控制的问题
稀有化更新托盘不允许用户自行设置可见性
【V25 2500U1】【更新管理系统】【企业级更新管理系统】【第八轮测试】客户端接入私有化成功后，任务栏设置中更新独立客户端应该不可取消勾选 【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第八轮测试】【系统更新】【公网】【任务栏】【更新状态插件】公网系统更新，控制中心插件区域更新状态配置项不应该展示更新独立客户端

Log：如上所述
Bug：
https://pms.uniontech.com/bug-view-359261.html
https://pms.uniontech.com/bug-view-359269.html
Influence：影响私有化更新托盘在控制中心的设置项