### PR TITLE
Develop/dcc update plugin private

### DIFF
--- a/src/dcc-update-plugin/operation/updatework.cpp
+++ b/src/dcc-update-plugin/operation/updatework.cpp
@@ -5,6 +5,7 @@
 #include "updatework.h"
 #include "common/common/logwatcherhelper.h"
 #include "common/dbus/mirrorinfolist.h"
+#include "common/commondefine.h"
 #include "utils.h"
 #include "dconfigwatcher.h"
 #include "common/common/dconfig_helper.h"
@@ -1773,7 +1774,11 @@ void UpdateWorker::setUpgradeDeliveryEnabled(bool enabled, bool fromRetryDialog)
             m_model->setUpgradeDeliveryEnable(enabled);
         }
     };
-    auto watcher = new QDBusPendingCallWatcher(m_updateInter->SetUpgradeDeliveryEnable(enabled), this);
+    QDBusInterface updateIface(UpdaterService, UpdaterPath, UpdaterInterface,
+                                    QDBusConnection::systemBus());
+    updateIface.setTimeout(30 * 60 * 1000);
+    QDBusPendingCall call = updateIface.asyncCall(QStringLiteral("SetP2PUpdateEnable"), enabled);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, [this, watcher, enabled, func_set_success] {
         watcher->deleteLater();
         if (watcher->isError()) {


### PR DESCRIPTION
V25 2500U1】【Update Management System】【Control Center Update Client】【Eighth Round Testing】【System Update】【Public Network】When enabling/disabling the delivery optimization setting without entering a password, a service error popup should not appear. Fix the above issue by extending the timeout to half an hour.

Log: As described above
Bug: https://pms.uniontech.com/bug-view-359331.html
Influence: Affects the timeout duration for authentication of the delivery master toggle switch

fix: 修改更新传递总开关的dbus调用等待时间
V25 2500U1】【更新管理系统】【控制中心更新客户端】【第八轮测试】【系统更新】【公网】传递优化设置项开启关闭不输入密码，不应该弹出服务异常弹窗 修复上述问题 将等待时间延长为半小时

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-359331.html Influence：影响更新传递总开关鉴权时的等待时间