### PR TITLE
fix: reorder dock icon creation before plugin registration

### DIFF
--- a/src/dock-update-plugin/pluginupdateplugin.cpp
+++ b/src/dock-update-plugin/pluginupdateplugin.cpp
@@ -229,13 +229,14 @@ void PluginUpdatePlugin::loadPlugin()
     if (m_pluginLoaded) {
         return;
     }
-    m_proxyInter->itemAdded(this, UPDATE_STATE_KEY);
-    m_pluginLoaded = true;
-    
     m_dockIcon.reset(new DockIconWidget);
     m_dockIcon->setFixedSize(Dock::DOCK_PLUGIN_ITEM_FIXED_SIZE);
     
     updateIconState();
+
+    m_proxyInter->itemAdded(this, UPDATE_STATE_KEY);
+    m_pluginLoaded = true;
+
     displayModeChanged(displayMode());
 }
 


### PR DESCRIPTION
The plugin icon widget must be fully initialized before registering with the proxy interface to ensure the dock manager has a valid widget reference when the itemAdded event is processed.

Log: Fixed plugin loading order for dock update icon

Influence:
1. Verify dock update icon appears correctly after plugin loading
2. Test plugin enable/disable flow to ensure consistent state
3. Check no visual artifacts or crashes on dock startup
4. Validate icon update behavior with different update states

fix: 调整停靠栏图标创建顺序至插件注册之前

插件图标部件必须在向代理接口注册之前完全初始化，以确保停靠栏管理器在处理
itemAdded 事件时拥有有效的部件引用。

Log: 修复插件加载顺序以正确显示更新图标

Influence:
1. 验证插件加载后更新图标正常显示
2. 测试插件启用/禁用流程，确保状态一致性
3. 检查停靠栏启动时无视觉异常或崩溃
4. 验证不同更新状态下图标更新行为

PMS: BUG-359275