### PR TITLE
chore: update changelog to 1.0.51

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-update-ui (1.0.51) unstable; urgency=medium
+
+  * fix: reorder dock icon creation before plugin registration
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 15:14:33 +0800
+
 deepin-update-ui (1.0.50) unstable; urgency=medium
 
   * fix(qml): fix button layout margin by adding right margin


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.51

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.51
- 目标分支: master
