### PR TITLE
fix: Gray out update transfer interface when updates are disabled

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateSetting.qml
+++ b/src/dcc-update-plugin/qml/UpdateSetting.qml
@@ -335,6 +335,7 @@ DccObject {
             parentName: "advancedSettingGroup"
             weight: 40
             visible: dccData.work().p2pUpdateSupported()
+            enabled: !dccData.model().updateProhibited
             pageType: DccObject.Item
             page: DccGroupView {
                 height: implicitHeight + 10
@@ -353,7 +354,7 @@ DccObject {
                 displayName: qsTr("Delivery Optimization")
                 description: qsTr("When enabled, your device may share previously downloaded system updates with other devices on your local network.When you turn it off, cached files from update delivery will be cleared during the next restart.")
                 weight: 10
-                enabled: !dccData.model().isPrivateUpdate
+                enabled: !dccData.model().isPrivateUpdate && !dccData.model().updateProhibited
                 pageType: DccObject.Editor
                 page: D.Switch {
                     id: upgradeDeliverySwitch
@@ -382,7 +383,7 @@ DccObject {
                 displayName: qsTr("Delivery Optimization-Upload throttling")
                 visible: dccData.model().upgradeDeliveryEnable
                 weight: 20
-                enabled: !dccData.model().upgradeUploadSpeedIsOnline
+                enabled: !dccData.model().upgradeUploadSpeedIsOnline && !dccData.model().updateProhibited
                 pageType: DccObject.Item
                 Connections {
                     target: dccData.model()
@@ -486,7 +487,7 @@ DccObject {
                 displayName: qsTr("Delivery Optimization-Limit Speed")
                 visible: dccData.model().upgradeDeliveryEnable
                 weight: 30
-                enabled: !dccData.model().upgradeDownloadSpeedIsOnline
+                enabled: !dccData.model().upgradeDownloadSpeedIsOnline && !dccData.model().updateProhibited
                 pageType: DccObject.Item
                 Connections {
                     target: dccData.model()

--- a/src/private-lastore-tray/privatelastoreplugin.cpp
+++ b/src/private-lastore-tray/privatelastoreplugin.cpp
@@ -48,7 +48,7 @@ const QString PrivateLastorePlugin::pluginName() const
 
 const QString PrivateLastorePlugin::pluginDisplayName() const
 {
-    return tr("Private Lastore");
+    return tr("Private Update");
 }
 
 void PrivateLastorePlugin::init(PluginProxyInterface *proxyInter)

--- a/src/private-lastore-tray/tipswidget.cpp
+++ b/src/private-lastore-tray/tipswidget.cpp
@@ -64,7 +64,7 @@ bool TipsWidget::checkShutdownUpdate()
     int lastoreStatus = DConfigHelper::instance()->getConfig("org.deepin.dde.lastore", "org.deepin.dde.lastore", "","lastore-daemon-status", 0).toInt();
     if (lastoreStatus == SHUTDOWNUPDATESTATUS) {
         m_textList.append(tr("Download complete"));
-        m_textList.append(tr("Shutdown update"));
+        m_textList.append(tr("Updates will begin on the next shutdown or restart"));
         return true;
     } else {
         return false;

--- a/src/private-lastore-tray/translations/private-lastore-tray_en.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>PrivateLastorePlugin</name>
     <message>
-        <source>Private Lastore</source>
+        <source>Private Update</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15,7 +15,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shutdown update</source>
+        <source>Updates will begin on the next shutdown or restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/private-lastore-tray/translations/private-lastore-tray_en_US.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_en_US.ts
@@ -4,7 +4,7 @@
 <context>
     <name>PrivateLastorePlugin</name>
     <message>
-        <source>Private Lastore</source>
+        <source>Private Update</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15,7 +15,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shutdown update</source>
+        <source>Updates will begin on the next shutdown or restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_CN.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_CN.ts
@@ -4,8 +4,8 @@
 <context>
     <name>PrivateLastorePlugin</name>
     <message>
-        <source>Private Lastore</source>
-        <translation>更新独立客户端</translation>
+        <source>Private Update</source>
+        <translation>私有化更新</translation>
     </message>
 </context>
 <context>
@@ -15,7 +15,7 @@
         <translation>更新包下载完成</translation>
     </message>
     <message>
-        <source>Shutdown update</source>
+        <source>Updates will begin on the next shutdown or restart</source>
         <translation>将在下次关机/重启时开始更新</translation>
     </message>
     <message>

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_HK.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_HK.ts
@@ -4,8 +4,8 @@
 <context>
     <name>PrivateLastorePlugin</name>
     <message>
-        <source>Private Lastore</source>
-        <translation>更新獨立客戶端</translation>
+        <source>Private Update</source>
+        <translation>私有化更新</translation>
     </message>
 </context>
 <context>
@@ -15,7 +15,7 @@
         <translation>更新包下載完成</translation>
     </message>
     <message>
-        <source>Shutdown update</source>
+        <source>Updates will begin on the next shutdown or restart</source>
         <translation>將在下次關機/重啟時開始更新</translation>
     </message>
     <message>

--- a/src/private-lastore-tray/translations/private-lastore-tray_zh_TW.ts
+++ b/src/private-lastore-tray/translations/private-lastore-tray_zh_TW.ts
@@ -4,8 +4,8 @@
 <context>
     <name>PrivateLastorePlugin</name>
     <message>
-        <source>Private Lastore</source>
-        <translation>更新獨立客戶端</translation>
+        <source>Private Update</source>
+        <translation>私有化更新</translation>
     </message>
 </context>
 <context>
@@ -15,7 +15,7 @@
         <translation>更新包下載完成</translation>
     </message>
     <message>
-        <source>Shutdown update</source>
+        <source>Updates will begin on the next shutdown or restart</source>
         <translation>將在下次關機/重新啟動時開始更新</translation>
     </message>
     <message>


### PR DESCRIPTION
[V25 2500U1][Update Management System][Control Center Update Client][Tenth Round Testing][System Update][Public Network][Control Center][System Update] When checking for updates is turned off, the transfer optimization related configuration items should be grayed out and non-operable

Log: As above
Bug: https://pms.uniontech.com/bug-view-360209.html
Influence: Affects the update transfer interface when updates are disabled

fix: 更新被禁用时更新传递界面置灰
【V25 2500U1】【更新管理系统】【控制中心更新客户端】【第十轮测试】【系统更新】【公网】【控制中心】【系统更新】关闭检查更新，传递优化相关配置项需要置灰不可操作

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-360209.html Influence：影响更新被禁用时更新传递界面