### PR TITLE
fix: Remove sorting logic for update system logs

### DIFF
--- a/src/dcc-update-plugin/operation/updateloghelper.cpp
+++ b/src/dcc-update-plugin/operation/updateloghelper.cpp
@@ -90,16 +90,6 @@ void UpdateLogHelper::handleSystem(const QJsonArray &log)
 
         m_systemLog.append(std::move(SystemUpdateLog::fromJsonObj(obj)));
     }
-
-    // 不依赖服务器返回来日志顺序，用showVersion进行排序
-    // 如果showVersion版本号相同，则用发布时间排序；不考虑版本号相同且发布时间相同的情况，这种情况应该由运维人员避免
-    std::sort(m_systemLog.begin(), m_systemLog.end(), [](const SystemUpdateLog& v1, const SystemUpdateLog& v2) -> bool {
-        int compareRet = v1.showVersion.compare(v2.showVersion);
-        if (compareRet == 0) {
-            return v1.publishTime.compare(v2.publishTime) >= 0;
-        }
-        return compareRet > 0;
-    });
 }
 
 void UpdateLogHelper::handleSecurity(const QJsonObject &log)


### PR DESCRIPTION
[V25 2500U1][Update Management System][Public Update Platform][First Round Testing] During community edition cross-version updates, not all intermediate version update logs are displayed, only the target baseline update log is shown The sorting order of update system log information is now solely determined by the update platform, the interface no longer performs any sorting

Log: As above
Bug: https://pms.uniontech.com/bug-view-354303.html
Influence: Affects the display order of update system logs

fix: 更新系统日志取消排序逻辑
【V25 2500U1】【更新管理系统】【公网更新平台】【第一轮测试】社区版跨版本更新时，未显示中间所有的版本更新日志，只显示目标基线更新日志 更新的系统日志信息统一交由更新平台去决定日志顺序，界面不再进行排序

Log：如上所述
Bug：https://pms.uniontech.com/bug-view-360209.html Influence：影响更新系统日志的显示顺序