### PR TITLE
fix: correct DBus service validity check in UpdateDbusProxy

### DIFF
--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -95,7 +95,7 @@ public:
     QDBusPendingCall CanRollback();
     QDBusPendingCall ConfirmRollback(bool confirm);
 
-    bool managerInterIsValid() const { return m_managerInter && m_managerInter->isValid(); }
+    bool managerInterIsValid() const { return m_managerInter && m_managerInter->serviceValid(); }
 
     QDBusPendingCall Poweroff(bool reboot = false);
 


### PR DESCRIPTION
Changed the validity check from `isValid()` to `serviceValid()` for the DBus manager interface. The original method incorrectly checked the interface object itself rather than verifying whether the underlying DBus service is actually registered and available. This caused status retrieval issues after the lastore-daemon service registration, as the check would succeed even when the service wasn't fully operational.

Log: Fixed service status check in DBus proxy

Influence:
1. Test service registration and status retrieval flow for lastore- daemon
2. Verify that proxy correctly detects when DBus service is unavailable
3. Test edge cases where service deregisters during operation

fix: 修正 UpdateDbusProxy 中 DBus 服务的有效性检查

将有效性检查从 `isValid()` 改为 `serviceValid()`。原先的方法错误地检查 了接口对象本身，而不是验证底层 DBus 服务是否已真正注册并可用。这会导致在
lastore-daemon 服务注册后获取状态出现问题，因为在服务未完全就绪时也能通
过检查。

Log: 修复 DBus 代理中的服务状态检查

Influence:
1. 测试 lastore-daemon 的服务注册和状态获取流程
2. 验证代理在 DBus 服务不可用时能正确检测
3. 测试服务在运行中注销的边界情况

PMS: BUG-361789
Change-Id: Ie796f222f20cb83ef8e04f2723bdad1d1f5e766f