### PR TITLE
fix: resolve lastore-daemon service registration status check issue

### DIFF
--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -95,7 +95,7 @@ public:
     QDBusPendingCall CanRollback();
     QDBusPendingCall ConfirmRollback(bool confirm);
 
-    bool managerInterIsValid() const { return m_managerInter && m_managerInter->serviceValid(); }
+    bool managerInterIsValid() const { return m_managerInter && m_managerInter->isValid(); }
 
     QDBusPendingCall Poweroff(bool reboot = false);
 

--- a/src/dde-update/main.cpp
+++ b/src/dde-update/main.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     new FullScreenManager(createFrame);
 
     if (!whetherDoUpgrade) {
-        UpdateWorker::instance()->doCheckSystem(UpdateModel::instance()->updateMode(), UpdateModel::instance()->checkSystemStage());
+        UpdateWorker::instance()->checkSystem(UpdateModel::instance()->updateMode(), UpdateModel::instance()->checkSystemStage());
     }
 
     return app->exec();

--- a/src/dde-update/updateworker.cpp
+++ b/src/dde-update/updateworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -76,6 +76,9 @@ void UpdateWorker::init()
         } else {
             if (m_waitingToCheckSystem) {
                 m_waitingToCheckSystem = false;
+                if (m_waitServiceTimer->isActive()) {
+                    m_waitServiceTimer->stop();
+                }
                 doCheckSystem(UpdateModel::instance()->updateMode(), UpdateModel::instance()->checkSystemStage());
             }
         }
@@ -106,6 +109,19 @@ void UpdateWorker::startUpdateProgress()
     qCInfo(logUpdateModal) << "Start update progress";
 
     doDistUpgradeIfCanBackup();
+}
+
+void UpdateWorker::checkSystem(int updateMode, UpdateModel::CheckSystemStage stage)
+{
+    qCInfo(logUpdateModal) << "Check system with update mode:" << updateMode << "check system stage:" << stage;
+    if (!m_dbusProxy->managerInterIsValid()) {
+        qCWarning(logUpdateModal) << "org.deepin.dde.Lastore1 interface is invalid, wait for service to be valid";
+        m_waitingToCheckSystem = true;
+        m_waitServiceTimer->start();
+        return;
+    }
+
+    doCheckSystem(updateMode, stage);
 }
 
 void UpdateWorker::doDistUpgrade(bool doBackup)
@@ -387,14 +403,7 @@ void UpdateWorker::doDistUpgradeIfCanBackup()
 
 void UpdateWorker::doCheckSystem(int updateMode, UpdateModel::CheckSystemStage stage)
 {
-    qCInfo(logUpdateModal) << "Update mode:" << updateMode << ", check system stage:" << stage;
-    if (!m_dbusProxy->managerInterIsValid()) {
-        qCWarning(logUpdateModal) << "org.deepin.dde.Lastore1 interface is invalid, wait for service to be valid";
-        m_waitingToCheckSystem = true;
-        m_waitServiceTimer->start();
-        return;
-    }
-
+    qCInfo(logUpdateModal) << "doCheckSystem Update mode:" << updateMode << ", check system stage:" << stage;
     QDBusPendingReply<QDBusObjectPath> reply = m_dbusProxy->CheckUpgrade(updateMode, static_cast<int>(stage));
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher] {

--- a/src/dde-update/updateworker.h
+++ b/src/dde-update/updateworker.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -43,6 +43,7 @@ public:
     void doCheckSystem(int updateMode, UpdateModel::CheckSystemStage stage);
     void doAction(UpdateModel::UpdateAction action);
     void startUpdateProgress();
+    void checkSystem(int updateMode, UpdateModel::CheckSystemStage stage);
     bool checkPower();
     void enableShortcuts(bool enable);
     void doPowerAction(bool reboot);


### PR DESCRIPTION
The update service registration was failing to properly check system status after the lastore-daemon became valid. Previously, the wait service timer was not being stopped when the check system was called from the timer callback, causing potential race conditions. Additionally, the doCheckSystem method contained the D-Bus service validity check, which was moved to a new checkSystem method that properly handles the waiting logic before calling doCheckSystem.

Log: Fixed system check after lastore-daemon service registration

Influence:
1. Test system check functionality when lastore-daemon service is already valid
2. Test system check when lastore-daemon service is not yet available and becomes valid later
3. Verify that wait service timer is properly stopped when service becomes valid
4. Verify that system check is not triggered twice due to timer race conditions
5. Test upgrade workflow end-to-end to ensure proper system check execution

fix: 修复lastore-daemon服务注册后获取状态问题

更新服务注册时，在lastore-daemon变为有效后未能正确检查系统状态。之前从
定时器回调调用checkSystem时没有停止等待服务定时器，可能导致竞态条件。
此外，doCheckSystem方法包含了D-Bus服务有效性检查，现在将其移动到新的
checkSystem方法中，该方法在调用doCheckSystem之前正确处理等待逻辑。

Log: 修复lastore-daemon服务注册后的系统检查

Influence:
1. 测试lastore-daemon服务已生效时的系统检查功能
2. 测试lastore-daemon服务尚未就绪后变为可用时的系统检查
3. 验证服务可用时等待服务定时器是否正常停止
4. 验证不会因定时器竞态条件导致系统检查被触发两次
5. 测试完整升级流程，确保系统检查正常执行

PMS: BUG-361789
Change-Id: I5de82d873a864673eb06482f09109c32f10cdc8f