### PR TITLE
chore: update changelog to 1.0.53

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-update-ui (1.0.53) unstable; urgency=medium
+
+  * fix: resolve lastore-daemon service registration status check issue
+  * fix: correct DBus service validity check in UpdateDbusProxy
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 20 May 2026 14:21:14 +0800
+
 deepin-update-ui (1.0.52) unstable; urgency=medium
 
   * fix: Gray out update transfer interface when updates are disabled


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.53

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.53
- 目标分支: master
