### PR TITLE
fix: remove redundant title label in dialog

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateHistoryDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateHistoryDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
@@ -22,14 +22,6 @@ D.DialogWindow {
         width: root.width// - DS.Style.dialogWindow.contentHMargin * 2
         spacing: 0
 
-        D.Label {
-            Layout.alignment: Qt.AlignHCenter
-            Layout.bottomMargin: 12
-            text: title
-            font: D.DTK.fontManager.t6
-            color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-            wrapMode: Text.WordWrap
-        }
 
         // 无更新历史时的提示
         Control {

--- a/src/dcc-update-plugin/qml/UpdateLogDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateLogDialog.qml
@@ -11,7 +11,6 @@ import org.deepin.dcc 1.0
 D.DialogWindow {
     id: root
     width: 480
-    height: 380
     icon: "preferences-system"
     modality: Qt.WindowModal
     title: qsTr("Update Log")
@@ -20,22 +19,13 @@ D.DialogWindow {
     signal exportBtnClicked()
 
     ColumnLayout {
-        anchors.fill: parent
+        width: root.width - root.leftPadding - root.rightPadding
         spacing: 10
-
-        D.Label {
-            id: titleLabel
-            Layout.alignment: Qt.AlignHCenter
-            text: title
-            font: D.DTK.fontManager.t6
-            color: D.DTK.themeType === D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-            wrapMode: Text.WordWrap
-        }
 
         ScrollView {
             id: scrollView
             Layout.fillWidth: true
-            Layout.preferredHeight: root.height - titleLabel.height - buttonRow.height - 80
+            Layout.preferredHeight: 340 - DS.Style.dialogWindow.titleBarHeight - buttonRow.implicitHeight - DS.Style.dialogWindow.contentVMargin
             clip: true
 
             background: Rectangle {
@@ -65,6 +55,7 @@ D.DialogWindow {
         // 按钮行
         RowLayout {
             id: buttonRow
+            Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
             spacing: 10
             
             Button {


### PR DESCRIPTION
1. Remove duplicated title Label from UpdateHistoryDialog since DialogWindow already displays the title in its title bar
2. Remove duplicated title Label from UpdateLogDialog for the same reason
3. Adjust layout constraints in UpdateLogDialog to properly fill content area without relying on fixed height

Log: Remove redundant title labels from update history and log dialogs

fix: 移除对话框中多余的标题标签

1. 移除 UpdateHistoryDialog 中重复的标题 Label，DialogWindow 标题栏已显示标题
2. 同理移除 UpdateLogDialog 中重复的标题 Label
3. 调整 UpdateLogDialog 布局约束，不再依赖固定高度

Log: 移除更新历史和更新日志对话框中多余的标题标签
PMS: BUG-362237