### PR TITLE
fix: clear update logs to prevent duplicate entries

### DIFF
--- a/src/dcc-update-plugin/operation/updateiteminfo.cpp
+++ b/src/dcc-update-plugin/operation/updateiteminfo.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -102,6 +102,11 @@ void UpdateItemInfo::addDetailInfo(DetailInfo detailInfo)
 {
     qCDebug(logDccUpdatePlugin) << "Add detail info for item:" << m_name;
     m_detailInfos.append(std::move(detailInfo));
+}
+
+void UpdateItemInfo::clearDetailInfos()
+{
+    m_detailInfos.clear();
 }
 
 void UpdateItemInfo::setPackages(const QStringList& packages)

--- a/src/dcc-update-plugin/operation/updateiteminfo.h
+++ b/src/dcc-update-plugin/operation/updateiteminfo.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -50,6 +50,7 @@ public:
     QList<DetailInfo> detailInfos() const;
     void setDetailInfos(QList<DetailInfo>& detailInfos);
     void addDetailInfo(DetailInfo detailInfo);
+    void clearDetailInfos();
 
     void setUpdateModeEnabled(bool enable) { m_enabled = enable; }
     bool isUpdateModeEnabled() const { return m_enabled; }

--- a/src/dcc-update-plugin/operation/updateloghelper.cpp
+++ b/src/dcc-update-plugin/operation/updateloghelper.cpp
@@ -95,6 +95,7 @@ void UpdateLogHelper::handleSystem(const QJsonArray &log)
 void UpdateLogHelper::handleSecurity(const QJsonObject &log)
 {
     qCDebug(logDccUpdatePlugin) << "Handling security log with" << log.keys().size() << "entries";
+    m_securityLog.clear();
     for (const auto& key : log.keys()) {
         const auto& obj = log.value(key).toObject();
         if (obj.isEmpty())
@@ -141,6 +142,8 @@ void UpdateLogHelper::handleSystemItemInfo(UpdateItemInfo *itemInfo) const
         return;
     }
 
+    itemInfo->setCurrentVersion("");
+    itemInfo->clearDetailInfos();
     for (const auto &log : m_systemLog) {
         const QString& explain = getLanguageType() == "CN" ? log.cnLog : log.enLog;
         itemInfo->setBaseline(log.baseline);
@@ -170,6 +173,7 @@ void UpdateLogHelper::handleSecurityItemInfo(UpdateItemInfo *itemInfo) const
         return;
     }
 
+    itemInfo->clearDetailInfos();
     QMap<VulLevel, int> vulCount;
     for (const auto &log : m_securityLog) {
         // 写入最近的更新


### PR DESCRIPTION
The previous implementation did not clear the security and system log containers before appending new log data. This caused duplicate log entries to accumulate when the update log data was refreshed, resulting in repeated display of update information each time the logs were processed. Added appropriate clearing mechanisms:
1. Clear m_securityLog before processing security log entries
2. Clear itemInfo's current version and detail infos before processing system item info
3. Add clearDetailInfos() method to UpdateItemInfo for consistent detail info management

Log: Fixed duplicate update log entries issue

Influence:
1. Test update log display after system updates
2. Verify that log entries do not duplicate when refreshing update information
3. Check that security update logs show correctly without repeated entries
4. Verify item info version and details are properly reset before new data is filled
5. Test multiple update cycles to ensure logs remain clean

fix: 修复更新日志重复问题

之前的实现没有在追加新的日志数据前清空安全日志和系统日志容器，导致每次处
理记录时，日志条目累加，更新信息重复显示。增加了相应的清理机制：
1. 处理安全日志条目前清空 m_securityLog
2. 处理系统项目信息前清空 itemInfo 的当前版本和详细信息
3. 在 UpdateItemInfo 中添加 clearDetailInfos() 方法确保详细信息一致性 管理

Log: 修复了更新日志重复显示的问题

Influence:
1. 测试系统更新后更新日志的显示情况
2. 验证刷新更新信息时日志条目不会重复
3. 检查安全更新日志是否正确显示，没有重复条目
4. 验证新数据填充前项目信息版本和详情正确重置
5. 测试多个更新周期确保日志保持清晰

PMS: BUG-362665
Change-Id: I2cbdf3016e3a35c0e805aa6008f5b4bf293f823b