### PR TITLE
chore: update changelog to 1.0.54

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-update-ui (1.0.54) unstable; urgency=medium
+
+  * fix: clear update logs to prevent duplicate entries
+  * fix: remove redundant title label in dialog
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 22 May 2026 18:09:49 +0800
+
 deepin-update-ui (1.0.53) unstable; urgency=medium
 
   * fix: resolve lastore-daemon service registration status check issue


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.54

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.54
- 目标分支: master
