### PR TITLE
fix: set QT scale env before launching dde-update in X11

### DIFF
--- a/src/dde-update/misc/98deepin-upgrade-check
+++ b/src/dde-update/misc/98deepin-upgrade-check
@@ -9,6 +9,15 @@ if [ "$XDG_SESSION_TYPE" = "x11" ]; then
             else
                 echo "Warning: Failed to start dde-update-env.service, running dde-update as fallback." >&2
             fi
+            xsettingsd_conf="/etc/lightdm/deepin/xsettingsd.conf"
+            # xsettingsd.conf 不存在时，通过 greeter-display-setting 设置 QT 缩放环境变量
+            if [ ! -e "$xsettingsd_conf" ]; then
+                greeter_display_setting_path="/usr/bin/greeter-display-setting"
+                if [ -f $greeter_display_setting_path ]; then
+                    scale_env=$(/usr/bin/greeter-display-setting | tail -1)
+                    export $scale_env
+                fi
+            fi
             /usr/bin/dde-update
         )
     fi


### PR DESCRIPTION
1. Fix AfterLogin progress ball and welcome text displayed too small after system upgrade due to inconsistent scaling
2. Check xsettingsd.conf existence before launching dde-update
3. Run xsettingsd with config if xsettingsd.conf exists
4. Fall back to greeter-display-setting for QT scale env vars

Log: Fix AfterLogin UI elements too small after upgrade by setting QT scale env in X11

fix: 在 X11 下启动 dde-update 前设置 QT 缩放环境变量

1. 修复系统升级后 AfterLogin 进度球和欢迎界面文案偏小、缩放与系统不一致的问题
2. 在启动 dde-update 前检查 xsettingsd.conf 是否存在
3. 若存在则使用该配置启动 xsettingsd
4. 若不存在则通过 greeter-display-setting 获取并导出 QT 缩放环境变量

Log: 修复系统升级后 AfterLogin 界面元素偏小的问题，在 X11 下提前设置 QT 缩放环境变量
PMS: BUG-363285