### PR TITLE
feat: adapt restart calls for Wayland via dde-session

### DIFF
--- a/src/common/commondefine.h
+++ b/src/common/commondefine.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -40,6 +40,11 @@ const static QString LockInterface = QStringLiteral("org.deepin.dde.LockService1
 const static QString ShutdownFront1Service = QStringLiteral("org.deepin.dde.ShutdownFront1");
 const static QString ShutdownFront1Path = QStringLiteral("/org/deepin/dde/ShutdownFront1");
 const static QString ShutdownFront1Interface = QStringLiteral("org.deepin.dde.ShutdownFront1");
+
+// SessionManager1
+const static QString SessionManager1Service = QStringLiteral("org.deepin.dde.SessionManager1");
+const static QString SessionManager1Path = QStringLiteral("/org/deepin/dde/SessionManager1");
+const static QString SessionManager1Interface = QStringLiteral("org.deepin.dde.SessionManager1");
 
 const static QString PropertiesInterface = QStringLiteral("org.freedesktop.DBus.Properties");
 const static QString PropertiesChanged = QStringLiteral("PropertiesChanged");

--- a/src/common/dbus/updatedbusproxy.cpp
+++ b/src/common/dbus/updatedbusproxy.cpp
@@ -10,6 +10,7 @@
 #include <QDBusReply>
 #include <QDBusUnixFileDescriptor>
 #include <QLoggingCategory>
+#include <DGuiApplicationHelper>
 
 #include "common/commondefine.h"
 
@@ -39,6 +40,8 @@ UpdateDBusProxy::UpdateDBusProxy(QObject *parent)
         LockService, LockPath, LockInterface, QDBusConnection::systemBus(), this))
     , m_shutdownFrontInter(new DDBusInterface(
         ShutdownFront1Service, ShutdownFront1Path, ShutdownFront1Interface, QDBusConnection::sessionBus(), this))
+    , m_sessionManagerInter(new DDBusInterface(
+        SessionManager1Service, SessionManager1Path, SessionManager1Interface, QDBusConnection::sessionBus(), this))
     , m_interWatcher(new QDBusServiceWatcher(UpdaterService, QDBusConnection::systemBus()))
 
 {
@@ -553,15 +556,27 @@ QString UpdateDBusProxy::CurrentUser()
 void UpdateDBusProxy::Restart()
 {
     qCInfo(logCommon) << "Calling system restart";
-    m_shutdownFrontInter->asyncCall(QStringLiteral("Restart"));
+    if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+        m_sessionManagerInter->asyncCall(QStringLiteral("RequestReboot"));
+    } else {
+        m_shutdownFrontInter->asyncCall(QStringLiteral("Restart"));
+    }
 }
 void UpdateDBusProxy::UpdateAndReboot()
 {
     qCInfo(logCommon) << "Calling update and reboot";
-    m_shutdownFrontInter->asyncCall(QStringLiteral("UpdateAndReboot"));
+    if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+        m_sessionManagerInter->asyncCall(QStringLiteral("RequestReboot"));
+    } else {
+        m_shutdownFrontInter->asyncCall(QStringLiteral("UpdateAndReboot"));
+    }
 }
 void UpdateDBusProxy::UpdateAndShutdown()
 {
     qCInfo(logCommon) << "Calling update and shutdown";
-    m_shutdownFrontInter->asyncCall(QStringLiteral("UpdateAndShutdown"));
+    if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+        m_sessionManagerInter->asyncCall(QStringLiteral("RequestShutdown"));
+    } else {
+        m_shutdownFrontInter->asyncCall(QStringLiteral("UpdateAndShutdown"));
+    }
 }

--- a/src/common/dbus/updatedbusproxy.h
+++ b/src/common/dbus/updatedbusproxy.h
@@ -188,6 +188,7 @@ private:
     DDBusInterface *m_login1Inter;
     DDBusInterface *m_lockServiceInter;
     DDBusInterface *m_shutdownFrontInter;
+    DDBusInterface *m_sessionManagerInter;
 
     QDBusServiceWatcher *m_interWatcher;
 };

--- a/src/dock-update-plugin/pluginupdateplugin.cpp
+++ b/src/dock-update-plugin/pluginupdateplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -189,12 +189,21 @@ void PluginUpdatePlugin::invokedMenuItem(const QString &itemKey, const QString &
             .call();
     } else if (menuId == MENU_RESTART) {
         // 重启系统
-        DDBusSender()
-            .service("org.deepin.dde.ShutdownFront1")
-            .interface("org.deepin.dde.ShutdownFront1")
-            .path("/org/deepin/dde/ShutdownFront1")
-            .method("Restart")
-            .call();
+        if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+            DDBusSender()
+                .service("org.deepin.dde.SessionManager1")
+                .interface("org.deepin.dde.SessionManager1")
+                .path("/org/deepin/dde/SessionManager1")
+                .method("RequestReboot")
+                .call();
+        } else {
+            DDBusSender()
+                .service("org.deepin.dde.ShutdownFront1")
+                .interface("org.deepin.dde.ShutdownFront1")
+                .path("/org/deepin/dde/ShutdownFront1")
+                .method("Restart")
+                .call();
+        }
     }
 }
 


### PR DESCRIPTION
Switched reboot, update-and-reboot, and update-and-shutdown operations to use the SessionManager1 D-Bus interface under Wayland, while keeping the existing ShutdownFront1 path for X11. This is needed because the old shutdown frontend does not work correctly on Wayland compositors, where session management must go through dde-session's dedicated API.

Log: Changed restart and shutdown methods to use SessionManager1 D-Bus interface on Wayland

Influence:
1. Test system restart on X11 (verify Restart is called via ShutdownFront1)
2. Test system restart on Wayland (verify RequestReboot is called via SessionManager1)
3. Test Update & Reboot on both platforms
4. Test Update & Shutdown on both platforms
5. Verify no regression for existing X11 shutdown frontend flows
6. Check error handling when SessionManager1 service is unavailable

feat: 在Wayland下重启服务改为调用dde-session接口

将重启、更新并重启、更新并关机等操作在Wayland环境下切换为使用
SessionManager1 D-Bus接口，X11下保持原有的ShutdownFront1调用。原因是旧的 关机前端在Wayland合成器上无法正常工作，需要通过dde-session的专用API进行
会话管理。

Log: 在Wayland环境下将重启和关机方法切换为使用SessionManager1 D-Bus接口

Influence:
1. 在X11下测试系统重启（验证通过ShutdownFront1调用Restart）
2. 在Wayland下测试系统重启（验证通过SessionManager1调用RequestReboot）
3. 在两个平台下测试“更新并重启”功能
4. 在两个平台下测试“更新并关机”功能
5. 验证现有X11关机前端流程无回归
6. 测试SessionManager1服务不可用时的错误处理

PMS: BUG-345663
Change-Id: I73c8449b6a96bdf00dc36510ceb8ecd7ffabb04f