### PR TITLE
chore: update changelog to 1.0.55

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-update-ui (1.0.55) unstable; urgency=medium
+
+  * feat: add post-upgrade check for Wayland in treeland environment
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 19:32:58 +0800
+
 deepin-update-ui (1.0.54) unstable; urgency=medium
 
   * fix: clear update logs to prevent duplicate entries


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.55

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.55
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 1.0.55 targeting master.