### PR TITLE
feat: add dbus service permission config for update plugin

### DIFF
--- a/src/dcc-update-plugin/CMakeLists.txt
+++ b/src/dcc-update-plugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -55,5 +55,10 @@ target_link_libraries(${Update_Name} PRIVATE
 )
 
 install(FILES "misc/org.deepin.dde.control-center.update.json" DESTINATION share/dsg/configs/org.deepin.dde.control-center)
+
+# security loader permission interfaces config
+install(FILES "misc/permission-interfaces/org.deepin.dcc-update-ui.json"
+    DESTINATION share/dde-control-center/permission-interfaces)
+
 dcc_install_plugin(NAME ${Update_Name} TARGET ${Update_Name})
 dcc_handle_plugin_translation(NAME ${Update_Name} )

--- a/src/dcc-update-plugin/misc/permission-interfaces/org.deepin.dcc-update-ui.json
+++ b/src/dcc-update-plugin/misc/permission-interfaces/org.deepin.dcc-update-ui.json
@@ -1,0 +1,11 @@
+{
+    "version": "1.0",
+    "description": "更新插件需要授权的 D-Bus 系统服务接口",
+    "DestList": [
+        {
+            "DbusName": "org.deepin.dde.Lastore1",
+            "DbusPath": "/org/deepin/dde/Lastore1",
+            "DbusInterface": "org.deepin.dde.Lastore1.Manager"
+        }
+    ]
+}


### PR DESCRIPTION
1. Add installation of permission-interfaces JSON config file for the update plugin
2. Define D-Bus service permission for org.deepin.dde.Lastore1 interface
3. Config file lists the dbus service, path, and interface required by the update plugin
4. This supports the control center's new security permission check mechanism

Log: Added D-Bus service permission config for update plugin

Influence:
1. Verify the permission-interfaces config file is installed to the correct directory
2. Check that the JSON config file contains valid syntax and content
3. Test update plugin functionality with the new permission check mechanism
4. Verify D-Bus communication with org.deepin.dde.Lastore1 service is properly authorized

feat: 为更新插件添加 D-Bus 服务权限配置

1. 添加更新插件的权限接口JSON配置文件安装
2. 定义 org.deepin.dde.Lastore1 接口的 D-Bus 服务权限
3. 配置文件列出更新插件所需的 D-Bus 服务、路径和接口
4. 配合控制中心新增的安全权限检查机制

Log: 新增更新插件的 D-Bus 服务权限配置

Influence:
1. 验证权限接口配置文件已安装到正确目录
2. 检查 JSON 配置文件语法和内容是否有效
3. 测试更新插件在新权限检查机制下的功能
4. 验证与 org.deepin.dde.Lastore1 服务的 D-Bus 通信已正确授权

PMS: TASK-390841
Change-Id: I4e9139e72210de6e8ee7a3e4be76869ed05e63e3