### PR TITLE
chore: update changelog to 1.0.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+deepin-update-ui (1.0.56) unstable; urgency=medium
+
+  * feat: add dbus service permission config for update plugin
+  * feat(shortcut): support multi-field searching for shortcuts
+  * refactor(eventreporter): convert namespace to class with LRU cache
+  * fix: use sigkill for wayland killClient()
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 19:45:36 +0800
+
 deepin-update-ui (1.0.55) unstable; urgency=medium
 
   * feat: add post-upgrade check for Wayland in treeland environment


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 1.0.56

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 1.0.56
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog version to 1.0.56 targeting the master branch.