### PR TITLE
fix: align release date and expand button in update list

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -117,6 +117,10 @@ Rectangle {
                                 text: qsTr("Release time:") + model.releaseTime
                             }
 
+                            Item {
+                                Layout.fillWidth: true
+                            }
+
                             D.ToolButton {
                                 textColor: D.Palette {
                                     normal {
@@ -191,6 +195,10 @@ Rectangle {
                                         font: D.DTK.fontManager.t8
                                         visible: itemCtl.showDetails && modelData.updateTime !== ""
                                         text: qsTr("Release time:") + modelData.updateTime
+                                    }
+
+                                    Item {
+                                        Layout.fillWidth: true
                                     }
 
                                     D.ToolButton {


### PR DESCRIPTION
Added flexible spacer items to properly separate release time text from tool buttons in the update list layout, ensuring consistent alignment across different list items.

Log: Fixed UI alignment in update list

Influence:
1. Verify release time text and expand button are properly separated
2. Test on different screen sizes and resolutions
3. Check alignment consistency across all list items

fix: 修复更新列表中发布日期和展开按钮的对齐问题

在更新列表布局中添加弹性分隔项，确保发布日期文本与工具按钮正确分离，保持
列表项间对齐一致性。

Log: 修复更新列表UI对齐问题

Influence:
1. 验证发布日期文本和展开按钮是否适当分离
2. 在不同屏幕尺寸和分辨率下测试
3. 检查所有列表项之间的对齐一致性

PMS: BUG-362721