### PR TITLE
fix: fix blank area in security update log details view

### DIFF
--- a/src/dcc-update-plugin/operation/updateiteminfo.h
+++ b/src/dcc-update-plugin/operation/updateiteminfo.h
@@ -62,6 +62,9 @@ public:
     void setIsChecked(bool isChecked);
     bool isChecked() const { return m_isChecked; }
 
+    void setExpanded(bool expanded) { m_expanded = expanded; }
+    bool isExpanded() const { return m_expanded; }
+
     UpdateType updateType() const { return m_updateType; }
 
     void setUpdateStatus(UpdatesStatus status);
@@ -91,6 +94,7 @@ private:
     QStringList m_packages;
     QList<DetailInfo> m_detailInfos;
     bool m_isChecked;
+    bool m_expanded = false;
     UpdatesStatus m_updateStatus;
     QString m_typeString;
 };

--- a/src/dcc-update-plugin/operation/updatelistmodel.cpp
+++ b/src/dcc-update-plugin/operation/updatelistmodel.cpp
@@ -48,6 +48,22 @@ QVariant UpdateListModel::data(const QModelIndex &index, int role) const
         return data->updateStatus();
     case IconName:
         return getIconName(data->updateType());
+    case Expanded:
+        return data->isExpanded();
+    case DetailInfos: {
+        QVariantList result;
+        const auto& detailInfos = data->detailInfos();
+        for (const auto& detail : detailInfos) {
+            QVariantMap map;
+            map["name"] = detail.name;
+            map["updateTime"] = detail.updateTime;
+            map["info"] = detail.info;
+            map["link"] = detail.link;
+            map["vulLevel"] = detail.vulLevel;
+            result.append(map);
+        }
+        return result;
+    }
     default:
         qCDebug(logDccUpdatePlugin) << "Unknown role requested:" << role;
         break;
@@ -55,18 +71,31 @@ QVariant UpdateListModel::data(const QModelIndex &index, int role) const
      return QVariant();
 }
 
-void UpdateListModel::addUpdateData(UpdateItemInfo* itemData)
+void UpdateListModel::syncData(const QList<UpdateItemInfo *> &items)
 {
-    qCDebug(logDccUpdatePlugin) << "Adding update data:" << itemData->name() << "type:" << itemData->updateType();
-    int row = rowCount();
-    beginInsertRows(QModelIndex(), row, row);
-    m_updateLists.append(itemData);
-    connect(itemData, &UpdateItemInfo::downloadSizeChanged, this, &UpdateListModel::refreshDownloadSize);
-    endInsertRows();
+    // 指针列表（含顺序）未变化，不触发 reset 避免滚动跳动。
+    // item 内部数据（如异步获取的日志）的变更通过 dataChanged 通知视图刷新；
+    if (items == m_updateLists) {
+        if (!m_updateLists.isEmpty()) {
+            emit dataChanged(index(0), index(m_updateLists.count() - 1));
+        }
+        refreshDownloadSize();
+        emit visibilityChanged();
+        return;
+    }
+
+    beginResetModel();
+    for (auto item : m_updateLists) {
+        disconnect(item, &UpdateItemInfo::downloadSizeChanged, this, &UpdateListModel::refreshDownloadSize);
+    }
+    m_updateLists = items;
+    for (auto item : m_updateLists) {
+        connect(item, &UpdateItemInfo::downloadSizeChanged, this, &UpdateListModel::refreshDownloadSize, Qt::UniqueConnection);
+    }
+    endResetModel();
 
     refreshDownloadSize();
     emit visibilityChanged();
-    qCDebug(logDccUpdatePlugin) << "Update data added, total items:" << m_updateLists.size();
 }
 
 QString UpdateListModel::getIconName(UpdateType type) const
@@ -180,6 +209,31 @@ void UpdateListModel::setChecked(int index, bool checked)
     }
 }
 
+void UpdateListModel::setExpanded(int index, bool expanded)
+{
+    if (index >= 0 && index < m_updateLists.count()) {
+        if (m_updateLists[index]->isExpanded() == expanded) {
+            return;
+        }
+        m_updateLists[index]->setExpanded(expanded);
+
+        QModelIndex changedIndex = this->index(index);
+        emit dataChanged(changedIndex, changedIndex, { Expanded });
+    } else {
+        qCWarning(logDccUpdatePlugin) << "Invalid index for setExpanded:" << index;
+    }
+}
+
+void UpdateListModel::collapseAll()
+{
+    for (int i = 0; i < m_updateLists.count(); ++i) {
+        if (m_updateLists[i]->isExpanded()) {
+            m_updateLists[i]->setExpanded(false);
+            emit dataChanged(index(i), index(i), { Expanded });
+        }
+    }
+}
+
 int UpdateListModel::getAllUpdateType() const
 {
     qCDebug(logDccUpdatePlugin) << "Getting combined update type for all checked items";
@@ -190,24 +244,4 @@ int UpdateListModel::getAllUpdateType() const
         }
     }
     return updateType;
-}
-
-QVariantList UpdateListModel::getDetailInfos(int index) const
-{
-    QVariantList result;
-    if (index >= 0 && index < m_updateLists.count()) {
-        const auto& detailInfos = m_updateLists[index]->detailInfos();
-        for (const auto& detail : detailInfos) {
-            QVariantMap map;
-            map["name"] = detail.name;
-            map["updateTime"] = detail.updateTime;
-            map["info"] = detail.info;
-            map["link"] = detail.link;
-            map["vulLevel"] = detail.vulLevel;
-            result.append(map);
-        }
-    } else {
-        qCWarning(logDccUpdatePlugin) << "Invalid index for getDetailInfos:" << index;
-    }
-    return result;
 }

--- a/src/dcc-update-plugin/operation/updatelistmodel.h
+++ b/src/dcc-update-plugin/operation/updatelistmodel.h
@@ -24,7 +24,9 @@ public:
         ReleaseTime,
         Checked,
         UpdateStatus,
-        IconName
+        IconName,
+        Expanded,
+        DetailInfos
     };
 
     explicit UpdateListModel(QObject *parent = nullptr);
@@ -34,11 +36,16 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    void addUpdateData(UpdateItemInfo *itemData);
+    // 用目标列表整体同步模型内容；当内容与当前一致时不发出任何信号，
+    // 避免无意义的 beginResetModel/endResetModel 造成视图重建与滚动跳动
+    void syncData(const QList<UpdateItemInfo *> &items);
 
     void clearAllData();
 
     Q_INVOKABLE void setChecked(int index, bool checked);
+
+    Q_INVOKABLE void setExpanded(int index, bool expanded);
+    Q_INVOKABLE void collapseAll();
 
     Q_INVOKABLE int getAllUpdateType() const;
 
@@ -54,6 +61,8 @@ public:
         roles[Checked] = "checked";
         roles[UpdateStatus] = "updateStatus";
         roles[IconName] = "iconName";
+        roles[Expanded] = "expanded";
+        roles[DetailInfos] = "detailInfos";
         return roles;
     }
 
@@ -62,7 +71,6 @@ public:
     QString downloadSize() const;
 
     Q_INVOKABLE UpdateType getUpdateType(int index) const;
-    Q_INVOKABLE QVariantList getDetailInfos(int index) const;
 
 public Q_SLOTS:
     void refreshDownloadSize();

--- a/src/dcc-update-plugin/operation/updatemodel.cpp
+++ b/src/dcc-update-plugin/operation/updatemodel.cpp
@@ -862,41 +862,18 @@ void UpdateModel::refreshUpdateStatus()
 void UpdateModel::refreshUpdateUiModel()
 {
     qCDebug(logDccUpdatePlugin) << "Refreshing update UI models";
-    if (m_preUpdatelistModel) {
-        m_preUpdatelistModel->clearAllData();
-    }
 
-    if (m_downloadinglistModel) {
-        m_downloadinglistModel->clearAllData();
-    }
-
-    if (m_installinglistModel) {
-        m_installinglistModel->clearAllData();
-    }
-
-    if (m_installCompleteListModel) {
-        m_installCompleteListModel->clearAllData();
-    }
-
-    if (m_installFailedListModel) {
-        m_installFailedListModel->clearAllData();
-    }
-
-    if (m_downloadFailedListModel) {
-        m_downloadFailedListModel->clearAllData();
-    }
-
-    if (m_preInstallListModel) {
-        m_preInstallListModel->clearAllData();
-    }
-
-    if (m_backingUpListModel) {
-        m_backingUpListModel->clearAllData();
-    }
-
-    if (m_backupFailedListModel) {
-        m_backupFailedListModel->clearAllData();
-    }
+    // 先按目标状态分桶，再用 syncData 整体同步；内容未变化的模型不会触发 reset，
+    // 从而避免勾选 CheckBox 等仅改变选中态的场景下列表重建与滚动跳动
+    QList<UpdateItemInfo *> preUpdateList;
+    QList<UpdateItemInfo *> downloadingList;
+    QList<UpdateItemInfo *> preInstallList;
+    QList<UpdateItemInfo *> downloadFailedList;
+    QList<UpdateItemInfo *> installingList;
+    QList<UpdateItemInfo *> installCompleteList;
+    QList<UpdateItemInfo *> installFailedList;
+    QList<UpdateItemInfo *> backingUpList;
+    QList<UpdateItemInfo *> backupFailedList;
 
     for (auto item : m_allUpdateInfos.values()) {
         qCDebug(logDccUpdatePlugin) << "refresh Update Ui:" << item->updateType() << item->updateStatus() << item->isUpdateModeEnabled();
@@ -905,44 +882,63 @@ void UpdateModel::refreshUpdateUiModel()
 
         switch (item->updateStatus()) {
         case Updated:
-            m_installCompleteListModel->addUpdateData(item);
+            installCompleteList.append(item);
             break;
         case UpdatesAvailable:
-            m_preUpdatelistModel->addUpdateData(item);
+            preUpdateList.append(item);
             break;
         case DownloadWaiting:
         case Downloading:
         case DownloadPaused:
         case UpgradeWaiting:
-            m_downloadinglistModel->addUpdateData(item);
+            downloadingList.append(item);
             break;
         case Downloaded:
-            m_preInstallListModel->addUpdateData(item);
+            preInstallList.append(item);
             break;
         case DownloadFailed:
-            m_downloadFailedListModel->addUpdateData(item);
+            downloadFailedList.append(item);
             break;
         case UpgradeReady:
         case Upgrading:
-            m_installinglistModel->addUpdateData(item);
+            installingList.append(item);
             break;
         case  UpgradeFailed:
-            m_installFailedListModel->addUpdateData(item);
+            installFailedList.append(item);
             break;
         case UpgradeSuccess:
         case UpgradeComplete:
-            m_installCompleteListModel->addUpdateData(item);
+            installCompleteList.append(item);
             break;
         case BackingUp:
         case BackupSuccess:
-            m_backingUpListModel->addUpdateData(item);
+            backingUpList.append(item);
             break;
         case BackupFailed:
-            m_backupFailedListModel->addUpdateData(item);
+            backupFailedList.append(item);
         default:
             break;
         }
     }
+
+    if (m_preUpdatelistModel)
+        m_preUpdatelistModel->syncData(preUpdateList);
+    if (m_downloadinglistModel)
+        m_downloadinglistModel->syncData(downloadingList);
+    if (m_preInstallListModel)
+        m_preInstallListModel->syncData(preInstallList);
+    if (m_downloadFailedListModel)
+        m_downloadFailedListModel->syncData(downloadFailedList);
+    if (m_installinglistModel)
+        m_installinglistModel->syncData(installingList);
+    if (m_installCompleteListModel)
+        m_installCompleteListModel->syncData(installCompleteList);
+    if (m_installFailedListModel)
+        m_installFailedListModel->syncData(installFailedList);
+    if (m_backingUpListModel)
+        m_backingUpListModel->syncData(backingUpList);
+    if (m_backupFailedListModel)
+        m_backupFailedListModel->syncData(backupFailedList);
 }
 
 void UpdateModel::updateAvailableState()

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -20,6 +20,12 @@ Rectangle {
     implicitHeight: layoutView.height
     Layout.fillWidth: true
 
+    Component.onDestruction: {
+        if (repeater.model) {
+            repeater.model.collapseAll()
+        }
+    }
+
     ColumnLayout {
         id: layoutView
         clip: true
@@ -39,225 +45,233 @@ Rectangle {
                 contentFlow: true
                 spacing: 0
 
-                property bool showDetails: false
+                property var detailModel: model.detailInfos
+                property bool showDetails: model.expanded
+                property int itemIndex: index
                 property bool isSecurityUpdate: repeater.model.getUpdateType(index) === Common.SecurityUpdate
 
-                content: RowLayout {
+                content: ColumnLayout {
                     spacing: 10
 
-                    D.DciIcon {
-                        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-                        name: model.iconName
-                        sourceSize {
-                            width: 28
-                            height: 28
-                        }
-                    }
+                    RowLayout {
+                        spacing: 10
 
-                    ColumnLayout {
-                        Layout.alignment: Qt.AlignRight
-                        spacing: 6
-
-                        RowLayout {
-                            Label {
-                                Layout.alignment: Qt.AlignLeft
-                                text: model.title
-                                font: D.DTK.fontManager.t6
-                                color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
-                                                          Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-                                width: 100
-                                Layout.fillWidth: true
+                        D.DciIcon {
+                            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                            name: model.iconName
+                            sourceSize {
+                                width: 28
+                                height: 28
                             }
+                        }
 
-                            DccCheckIcon {
-                                Layout.alignment: Qt.AlignRight
-                                checked: model.checked
-                                size: 18
-                                visible: checkIconVisible
+                        ColumnLayout {
+                            Layout.alignment: Qt.AlignRight
+                            spacing: 6
 
-                                onClicked: {
-                                    repeater.model.setChecked(index, !model.checked)
-                                    dccData.work().setCheckUpdateMode(repeater.model.getUpdateType(index), model.checked)
+                            RowLayout {
+                                Label {
+                                    Layout.alignment: Qt.AlignLeft
+                                    text: model.title
+                                    font: D.DTK.fontManager.t6
+                                    color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
+                                                            Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                    width: 100
+                                    Layout.fillWidth: true
+                                }
+
+                                DccCheckIcon {
+                                    Layout.alignment: Qt.AlignRight
+                                    checked: model.checked
+                                    size: 18
+                                    visible: checkIconVisible
+
+                                    onClicked: {
+                                        repeater.model.setChecked(index, !model.checked)
+                                        dccData.work().setCheckUpdateMode(repeater.model.getUpdateType(index), model.checked)
+                                    }
                                 }
                             }
-                        }
 
-                        D.Label {
-                            Layout.alignment: Qt.AlignLeft
-                            horizontalAlignment: Text.AlignLeft
-                            Layout.fillWidth: true
-                            font: D.DTK.fontManager.t8
-                            color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
-                                                      Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-                            visible: model.version.length !== 0
-                            text: qsTr("Version:") + model.version
-                        }
-
-                        D.Label {
-                            Layout.alignment: Qt.AlignLeft
-                            horizontalAlignment: Text.AlignLeft
-                            Layout.fillWidth: true
-                            font: D.DTK.fontManager.t8
-                            text: model.explain
-                            textFormat: Text.RichText
-                            wrapMode: Text.WordWrap
-                            onLinkActivated: (link)=> {
-                                dccData.work().openUrl(link)
-                            }
-                            MouseArea {
-                                anchors.fill: parent
-                                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                                acceptedButtons: Qt.NoButton
-                            }
-                        }
-
-                        RowLayout {
                             D.Label {
                                 Layout.alignment: Qt.AlignLeft
                                 horizontalAlignment: Text.AlignLeft
-                                verticalAlignment: Text.AlignVCenter
                                 Layout.fillWidth: true
-                                Layout.minimumHeight: 22
                                 font: D.DTK.fontManager.t8
-                                visible: model.releaseTime.length !== 0
-                                text: qsTr("Release time:") + model.releaseTime
+                                color: D.DTK.themeType == D.ApplicationHelper.LightType ? 
+                                                        Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                visible: model.version.length !== 0
+                                text: qsTr("Version:") + model.version
                             }
 
-                            Item {
+                            D.Label {
+                                Layout.alignment: Qt.AlignLeft
+                                horizontalAlignment: Text.AlignLeft
                                 Layout.fillWidth: true
-                            }
-
-                            D.ToolButton {
-                                textColor: D.Palette {
-                                    normal {
-                                        common: D.DTK.makeColor(D.Color.Highlight)
-                                    }
-                                    normalDark: normal
-                                    hovered {
-                                        common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
-                                    }
-                                    hoveredDark: hovered
-                                }
-                                visible: repeater.model.getDetailInfos(index).length !== 0 && !itemCtl.showDetails
-                                bottomPadding: 0
                                 font: D.DTK.fontManager.t8
-                                text: qsTr("View More")
-                                onClicked: {
-                                    itemCtl.showDetails = true
+                                text: model.explain
+                                textFormat: Text.RichText
+                                wrapMode: Text.WordWrap
+                                onLinkActivated: (link)=> {
+                                    dccData.work().openUrl(link)
                                 }
-                                background: Item {}
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                    acceptedButtons: Qt.NoButton
+                                }
                             }
 
-                            Component.onDestruction: {
-                                itemCtl.showDetails = false
+                            RowLayout {
+                                D.Label {
+                                    Layout.alignment: Qt.AlignLeft
+                                    horizontalAlignment: Text.AlignLeft
+                                    verticalAlignment: Text.AlignVCenter
+                                    Layout.fillWidth: true
+                                    Layout.minimumHeight: 22
+                                    font: D.DTK.fontManager.t8
+                                    visible: model.releaseTime.length !== 0
+                                    text: qsTr("Release time:") + model.releaseTime
+                                }
+
+                                Item {
+                                    Layout.fillWidth: true
+                                }
+
+                                D.ToolButton {
+                                    textColor: D.Palette {
+                                        normal {
+                                            common: D.DTK.makeColor(D.Color.Highlight)
+                                        }
+                                        normalDark: normal
+                                        hovered {
+                                            common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
+                                        }
+                                        hoveredDark: hovered
+                                    }
+                                    visible: model.detailInfos.length !== 0 && !itemCtl.showDetails
+                                    bottomPadding: 0
+                                    font: D.DTK.fontManager.t8
+                                    text: qsTr("View More")
+                                    onClicked: {
+                                        repeater.model.setExpanded(itemCtl.itemIndex, true)
+                                    }
+                                    background: Item {}
+                                }
                             }
-                        }
 
-                        Rectangle {
-                            height: 1
-                            color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
-                                                       Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
-                            Layout.fillWidth: true
-                            visible: itemCtl.showDetails
-                        }
+                            Rectangle {
+                                height: 1
+                                color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
+                                                        Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
+                                Layout.fillWidth: true
+                                visible: itemCtl.showDetails
+                            }
 
-                        // 详情列表
-                        Repeater {
-                            id: innerRepeater
-                            model: repeater.model.getDetailInfos(index)
-                            ColumnLayout {
-                                spacing: 6
+                            // 详情列表
+                            Repeater {
+                                id: innerRepeater
+                                model: itemCtl.detailModel
+                                ColumnLayout {
+                                    spacing: 6
 
-                                D.Label {
-                                    Layout.alignment: Qt.AlignLeft
-                                    horizontalAlignment: Text.AlignLeft
-                                    Layout.fillWidth: true
-                                    font: D.DTK.fontManager.t8
-                                    color: D.DTK.themeType == D.ApplicationHelper.LightType ?
-                                                              Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-                                    visible: itemCtl.showDetails && modelData.name !== ""
-                                    text: (itemCtl.isSecurityUpdate ? qsTr("Vulnerability ID:") : qsTr("Version:")) + modelData.name
-                                }
+                                    visible: itemCtl.showDetails
 
-                                D.Label {
-                                    Layout.alignment: Qt.AlignLeft
-                                    horizontalAlignment: Text.AlignLeft
-                                    Layout.fillWidth: true
-                                    font: D.DTK.fontManager.t8
-                                    color: D.DTK.themeType == D.ApplicationHelper.LightType ?
-                                                              Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
-                                    visible: itemCtl.showDetails && itemCtl.isSecurityUpdate && modelData.vulLevel !== ""
-                                    text: qsTr("Severity:") + modelData.vulLevel
-                                }
-
-                                D.Label {
-                                    Layout.alignment: Qt.AlignLeft
-                                    horizontalAlignment: Text.AlignLeft
-                                    Layout.fillWidth: true
-                                    font: D.DTK.fontManager.t8
-                                    visible: itemCtl.showDetails && modelData.info !== ""
-                                    text: itemCtl.isSecurityUpdate ? qsTr("Description:") + modelData.info : modelData.info
-                                    textFormat: Text.RichText
-                                    wrapMode: Text.WordWrap
-                                    onLinkActivated: (link)=> {
-                                        dccData.work().openUrl(link)
-                                    }
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-                                        acceptedButtons: Qt.NoButton
-                                    }
-                                }
-
-                                RowLayout {
                                     D.Label {
                                         Layout.alignment: Qt.AlignLeft
                                         horizontalAlignment: Text.AlignLeft
                                         Layout.fillWidth: true
                                         font: D.DTK.fontManager.t8
-                                        visible: itemCtl.showDetails && modelData.updateTime !== ""
-                                        text: qsTr("Release time:") + modelData.updateTime
+                                        color: D.DTK.themeType == D.ApplicationHelper.LightType ?
+                                                                Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                        visible: itemCtl.showDetails && modelData.name !== ""
+                                        text: (itemCtl.isSecurityUpdate ? qsTr("Vulnerability ID:") : qsTr("Version:")) + modelData.name
                                     }
 
-                                    Item {
+                                    D.Label {
+                                        Layout.alignment: Qt.AlignLeft
+                                        horizontalAlignment: Text.AlignLeft
                                         Layout.fillWidth: true
-                                    }
-
-                                    D.ToolButton {
-                                        textColor: D.Palette {
-                                            normal {
-                                                common: D.DTK.makeColor(D.Color.Highlight)
-                                            }
-                                            normalDark: normal
-                                            hovered {
-                                                common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
-                                            }
-                                            hoveredDark: hovered
-                                        }
-                                        visible: itemCtl.showDetails && (index === innerRepeater.count - 1 )
-                                        bottomPadding: 0
                                         font: D.DTK.fontManager.t8
-                                        text: qsTr("Collapse")
-                                        onClicked: {
-                                            itemCtl.showDetails = false
+                                        color: D.DTK.themeType == D.ApplicationHelper.LightType ?
+                                                                Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                                        visible: itemCtl.showDetails && itemCtl.isSecurityUpdate && modelData.vulLevel !== ""
+                                        text: qsTr("Severity:") + modelData.vulLevel
+                                    }
+
+                                    D.Label {
+                                        Layout.alignment: Qt.AlignLeft
+                                        horizontalAlignment: Text.AlignLeft
+                                        Layout.fillWidth: true
+                                        font: D.DTK.fontManager.t8
+                                        visible: itemCtl.showDetails && modelData.info !== ""
+                                        text: itemCtl.isSecurityUpdate ? qsTr("Description:") + modelData.info : modelData.info
+                                        textFormat: Text.RichText
+                                        wrapMode: Text.WordWrap
+                                        onLinkActivated: (link)=> {
+                                            dccData.work().openUrl(link)
                                         }
-                                        background: Item {}
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                            acceptedButtons: Qt.NoButton
+                                        }
                                     }
 
-                                    Component.onDestruction:   {
-                                        itemCtl.showDetails = false
-                                    }
-                                }
+                                    RowLayout {
+                                        D.Label {
+                                            Layout.alignment: Qt.AlignLeft
+                                            horizontalAlignment: Text.AlignLeft
+                                            Layout.fillWidth: true
+                                            font: D.DTK.fontManager.t8
+                                            visible: itemCtl.showDetails && modelData.updateTime !== ""
+                                            text: qsTr("Release time:") + modelData.updateTime
+                                        }
 
-                                Rectangle {
-                                    height: 1
-                                    color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
-                                                               Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
-                                    Layout.fillWidth: true
-                                    visible: itemCtl.showDetails && (index !== innerRepeater.count - 1 )
+                                        Item {
+                                            Layout.fillWidth: true
+                                        }
+
+                                        D.ToolButton {
+                                            textColor: D.Palette {
+                                                normal {
+                                                    common: D.DTK.makeColor(D.Color.Highlight)
+                                                }
+                                                normalDark: normal
+                                                hovered {
+                                                    common: D.DTK.makeColor(D.Color.Highlight).lightness(+30)
+                                                }
+                                                hoveredDark: hovered
+                                            }
+                                            visible: itemCtl.showDetails && (index === innerRepeater.count - 1 )
+                                            bottomPadding: 0
+                                            font: D.DTK.fontManager.t8
+                                            text: qsTr("Collapse")
+                                            onClicked: {
+                                                repeater.model.setExpanded(itemCtl.itemIndex, false)
+                                            }
+                                            background: Item {}
+                                        }
+                                    }
+
+                                    Rectangle {
+                                        height: 1
+                                        color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
+                                                                Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
+                                        Layout.fillWidth: true
+                                        visible: itemCtl.showDetails && (index !== innerRepeater.count - 1 )
+                                    }
                                 }
                             }
                         }
+                    }
+
+                    Rectangle {
+                        height: 1
+                        color: D.DTK.themeType === D.ApplicationHelper.LightType ? 
+                                                Qt.rgba(0, 0, 0, 0.05) : Qt.rgba(1, 1, 1, 0.05)
+                        Layout.fillWidth: true
+                        visible: (index !== repeater.count - 1 )
                     }
                 }
 


### PR DESCRIPTION
1. Remove the dependency on getDetailInfos Q_INVOKABLE method by exposing DetailInfos and Expanded roles directly in the model
2. Add setExpanded Q_INVOKABLE method to the model to properly manage the expanded state
3. Sync data efficiently using syncData which avoids unnecessary beginResetModel/endResetModel when the pointer list hasn't changed
4. Simplify the QML view to use model.expanded and model.detailInfos directly from the model roles
5. Move the showDetails property from local state to model-backed state to persist expansion correctly when data refreshes
6. Use the model's setExpanded method when clicking "View More" or "Collapse" buttons
7. Add setExpanded/isExpanded methods to UpdateItemInfo to persist the expanded state per item
8. Fix the issue where the "View More" button was incorrectly visible due to stale local state
9. Replace clearAllData+addUpdateData pattern with syncData to prevent unnecessary model reset when only the selected state changes

Log: Fixed security update log details display with proper expansion state management

Influence:
1. Verify "View More" button appears correctly for security update items with detail logs
2. Click "View More" and verify the detail information displays correctly
3. Click "Collapse" and verify the details hide properly
4. Verify the expanded state persists when other updates or UI refreshes occur
5. Verify the "View More" button shows for items without details and does not expand to avoid blank areas
6. Test that checking/unchecking update items does not cause the list to scroll or collapse details
7. Verify the detail content displays correctly for both security updates and regular updates

fix: 修复安全更新日志详情页出现空白区域问题

1. 通过直接暴露 DetailInfos 和 Expanded 角色到模型中，移除对 getDetailInfos Q_INVOKABLE 方法的依赖
2. 在模型中添加 setExpanded Q_INVOKABLE 方法来正确管理展开状态
3. 使用 syncData 方法高效同步数据，避免在指针列表未变化时触发不必要的 beginResetModel/endResetModel
4. 简化 QML 视图，直接使用模型角色 model.expanded 和 model.detailInfos
5. 将 showDetails 属性从本地状态迁移到模型支持的存储，以在数据刷新时正确 保持展开状态
6. 点击"查看详情"或"收起"按钮时，使用模型的 setExpanded 方法
7. 在 UpdateItemInfo 中添加 setExpanded/isExpanded 方法，以持久化每个项 目的展开状态
8. 修复由于本地状态过期导致"查看详情"按钮显示异常的问题
9. 使用 syncData 替代 clearAllData+addUpdateData 模式，防止仅在选中状态 变化时触发不必要的模型重置

Log: 修复安全更新日志详情显示问题，改进展开状态管理

Influence:
1. 验证安全更新项目在有详情日志时正确显示"查看详情"按钮
2. 点击"查看详情"后验证详情信息正确显示
3. 点击"收起"后验证详情正确隐藏
4. 验证在其他更新或UI刷新时展开状态保持不变
5. 验证无详情项目不显示"查看详情"按钮，避免出现空白区域
6. 测试勾选/取消勾选更新项目时，不会导致列表滚动或详情折叠
7. 验证详情内容在安全更新和普通更新中都能正确显示

PMS: BUG-367683
Change-Id: I383dadacaf4217e28e25b32e7ce55aebaf32506c