### PR TITLE
fix: improve security update label formatting and translations

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateHistoryDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateHistoryDialog.qml
@@ -148,7 +148,7 @@ D.DialogWindow {
                                     text: {
                                         switch(Type) {
                                         case 1: return qsTr("Version:") + modelData.name
-                                        case 4: return modelData.name
+                                        case 4: return qsTr("Vulnerability ID: ") + modelData.name
                                         default: return ""
                                         }
                                     }
@@ -159,7 +159,7 @@ D.DialogWindow {
                                     Layout.fillWidth: true
                                 }
                                 Label {
-                                    text: modelData.displayVulLevel
+                                    text: qsTr("Severity: ") + modelData.displayVulLevel
                                     visible: modelData.displayVulLevel !== ""
                                     font: D.DTK.fontManager.t8
                                     color: D.DTK.themeType == D.ApplicationHelper.LightType ? Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
@@ -178,7 +178,9 @@ D.DialogWindow {
                                     }
                                 }
                                 Label {
-                                    text: modelData.description
+                                    text: {
+                                        Type === 4 ? qsTr("Description: ") + modelData.description : modelData.description
+                                    }
                                     visible: modelData.description !== ""
                                     font: D.DTK.fontManager.t8
                                     wrapMode: Text.WordWrap

--- a/src/dcc-update-plugin/qml/UpdateList.qml
+++ b/src/dcc-update-plugin/qml/UpdateList.qml
@@ -185,7 +185,7 @@ Rectangle {
                                         color: D.DTK.themeType == D.ApplicationHelper.LightType ?
                                                                 Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                                         visible: itemCtl.showDetails && modelData.name !== ""
-                                        text: (itemCtl.isSecurityUpdate ? qsTr("Vulnerability ID:") : qsTr("Version:")) + modelData.name
+                                        text: (itemCtl.isSecurityUpdate ? qsTr("Vulnerability ID: ") : qsTr("Version:")) + modelData.name
                                     }
 
                                     D.Label {
@@ -196,7 +196,7 @@ Rectangle {
                                         color: D.DTK.themeType == D.ApplicationHelper.LightType ?
                                                                 Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                                         visible: itemCtl.showDetails && itemCtl.isSecurityUpdate && modelData.vulLevel !== ""
-                                        text: qsTr("Severity:") + modelData.vulLevel
+                                        text: qsTr("Severity: ") + modelData.vulLevel
                                     }
 
                                     D.Label {
@@ -205,7 +205,7 @@ Rectangle {
                                         Layout.fillWidth: true
                                         font: D.DTK.fontManager.t8
                                         visible: itemCtl.showDetails && modelData.info !== ""
-                                        text: itemCtl.isSecurityUpdate ? qsTr("Description:") + modelData.info : modelData.info
+                                        text: itemCtl.isSecurityUpdate ? qsTr("Description: ") + modelData.info : modelData.info
                                         textFormat: Text.RichText
                                         wrapMode: Text.WordWrap
                                         onLinkActivated: (link)=> {

--- a/src/dcc-update-plugin/translations/update_ar.ts
+++ b/src/dcc-update-plugin/translations/update_ar.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_az.ts
+++ b/src/dcc-update-plugin/translations/update_az.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>طي</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_bn.ts
+++ b/src/dcc-update-plugin/translations/update_bn.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_bo.ts
+++ b/src/dcc-update-plugin/translations/update_bo.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ca.ts
+++ b/src/dcc-update-plugin/translations/update_ca.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Versió:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Replega</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_cs.ts
+++ b/src/dcc-update-plugin/translations/update_cs.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_da.ts
+++ b/src/dcc-update-plugin/translations/update_da.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_de.ts
+++ b/src/dcc-update-plugin/translations/update_de.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_de_DE.ts
+++ b/src/dcc-update-plugin/translations/update_de_DE.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Version:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished">Einfahren</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_el.ts
+++ b/src/dcc-update-plugin/translations/update_el.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_en.ts
+++ b/src/dcc-update-plugin/translations/update_en.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_en_US.ts
+++ b/src/dcc-update-plugin/translations/update_en_US.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_es.ts
+++ b/src/dcc-update-plugin/translations/update_es.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Versión:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Contraer</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_et.ts
+++ b/src/dcc-update-plugin/translations/update_et.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_fi.ts
+++ b/src/dcc-update-plugin/translations/update_fi.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Versio:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Tiivistetty</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_fr.ts
+++ b/src/dcc-update-plugin/translations/update_fr.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Version :</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished">Réduire</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_gl_ES.ts
+++ b/src/dcc-update-plugin/translations/update_gl_ES.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_he.ts
+++ b/src/dcc-update-plugin/translations/update_he.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_hr.ts
+++ b/src/dcc-update-plugin/translations/update_hr.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_hu.ts
+++ b/src/dcc-update-plugin/translations/update_hu.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_it.ts
+++ b/src/dcc-update-plugin/translations/update_it.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ja.ts
+++ b/src/dcc-update-plugin/translations/update_ja.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>バージョン</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>折りたたむ</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_kk.ts
+++ b/src/dcc-update-plugin/translations/update_kk.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ko.ts
+++ b/src/dcc-update-plugin/translations/update_ko.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_lo.ts
+++ b/src/dcc-update-plugin/translations/update_lo.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">ຮຸ່ນ:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>ຫຍໍ້</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_lt.ts
+++ b/src/dcc-update-plugin/translations/update_lt.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ms.ts
+++ b/src/dcc-update-plugin/translations/update_ms.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_nb_NO.ts
+++ b/src/dcc-update-plugin/translations/update_nb_NO.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ne.ts
+++ b/src/dcc-update-plugin/translations/update_ne.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_nl.ts
+++ b/src/dcc-update-plugin/translations/update_nl.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Versie:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Inklappen</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_pl.ts
+++ b/src/dcc-update-plugin/translations/update_pl.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Wersja:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Zwiń</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_pt.ts
+++ b/src/dcc-update-plugin/translations/update_pt.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_pt_BR.ts
+++ b/src/dcc-update-plugin/translations/update_pt_BR.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Versão:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Recolher</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ro.ts
+++ b/src/dcc-update-plugin/translations/update_ro.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ru.ts
+++ b/src/dcc-update-plugin/translations/update_ru.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Версия:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Свернуть</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_sl.ts
+++ b/src/dcc-update-plugin/translations/update_sl.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Zaklopi</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_sq.ts
+++ b/src/dcc-update-plugin/translations/update_sq.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>Version:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Palose</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_sr.ts
+++ b/src/dcc-update-plugin/translations/update_sr.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_tr.ts
+++ b/src/dcc-update-plugin/translations/update_tr.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Sürüm:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Daralt</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_ug.ts
+++ b/src/dcc-update-plugin/translations/update_ug.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_uk.ts
+++ b/src/dcc-update-plugin/translations/update_uk.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished">Версія:</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>Згорнути</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_vi.ts
+++ b/src/dcc-update-plugin/translations/update_vi.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_zh_CN.ts
+++ b/src/dcc-update-plugin/translations/update_zh_CN.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation>漏洞编号：</translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation>漏洞等级：</translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation>漏洞描述：</translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>收起详细</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation>漏洞编号：</translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation>漏洞等级：</translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation>漏洞描述：</translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_zh_HK.ts
+++ b/src/dcc-update-plugin/translations/update_zh_HK.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation>漏洞編號：</translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation>漏洞等級：</translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation>漏洞描述：</translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>收起詳細</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
+        <source>Vulnerability ID: </source>
         <translation>漏洞編號：</translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation>漏洞等級：</translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation>漏洞描述：</translation>
     </message>
 </context>

--- a/src/dcc-update-plugin/translations/update_zh_TW.ts
+++ b/src/dcc-update-plugin/translations/update_zh_TW.ts
@@ -81,6 +81,18 @@
         <source>Version:</source>
         <translation>版本：</translation>
     </message>
+    <message>
+        <source>Vulnerability ID: </source>
+        <translation>漏洞編號：</translation>
+    </message>
+    <message>
+        <source>Severity: </source>
+        <translation>漏洞等級：</translation>
+    </message>
+    <message>
+        <source>Description: </source>
+        <translation>漏洞描述：</translation>
+    </message>
 </context>
 <context>
     <name>UpdateList</name>
@@ -101,15 +113,15 @@
         <translation>收起詳細</translation>
     </message>
     <message>
-        <source>Vulnerability ID:</source>
-        <translation> 漏洞編號：</translation>
+        <source>Vulnerability ID: </source>
+        <translation>漏洞編號：</translation>
     </message>
     <message>
-        <source>Severity:</source>
+        <source>Severity: </source>
         <translation>漏洞等級：</translation>
     </message>
     <message>
-        <source>Description:</source>
+        <source>Description: </source>
         <translation>漏洞描述：</translation>
     </message>
 </context>


### PR DESCRIPTION
Add proper labels for vulnerability IDs, severity, and descriptions in the update history dialog. Standardize label text with a trailing space for consistency between the update list and history dialog views. Update all translation files accordingly.

Log: Improved security update detail labels for better readability

Influence:
1. Verify that vulnerability ID, severity, and description labels appear correctly in both the update list and history dialog
2. Test with different update types (security vs version updates) to ensure proper label behavior
3. Check that labels are properly translated in supported languages
4. Verify that the history dialog correctly shows labels only for type=4 (security vulnerability) items
5. Test with various severity levels and vulnerability IDs to ensure consistent display

fix: 改进安全更新标签格式和翻译

在更新历史对话框中为漏洞ID、严重级别和描述添加适当的标签。统一标签文本，
在更新列表和历史对话框视图之间保持一致。更新所有翻译文件。

Log: 改进安全更新详情标签，提升可读性

Influence:
1. 验证漏洞ID、严重级别和描述标签在更新列表和历史对话框中正确显示
2. 测试不同更新类型（安全更新与版本更新），确保标签行为正确
3. 检查标签在支持的语言中是否正确翻译
4. 验证历史对话框仅对类型为4（安全漏洞）的项显示标签
5. 测试不同严重级别和漏洞ID，确保显示一致

PMS: BUG-367965 BUG-367957