### PR TITLE
feat: integrate security-loader and FIFO-based lifecycle management for dde-update

### DIFF
--- a/src/dde-update/CMakeLists.txt
+++ b/src/dde-update/CMakeLists.txt
@@ -58,7 +58,7 @@ include(GNUInstallDirs)
 ## qm files
 install(FILES ${TR_QM_FILES} DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/translations)
 
-install(TARGETS ${UPDATE_EXEC_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ${UPDATE_EXEC_NAME} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/deepin)
 
 install(FILES "misc/99_system_upgrade_conf.json"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/dde-session-shell/greeters.d/launch.conf.d)
@@ -86,7 +86,9 @@ install(PROGRAMS "misc/98deepin-upgrade-check"
         DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/X11/Xsession.d)
 
 install(PROGRAMS 
+        "misc/dde-update"
         "misc/system_upgrade_check.sh"
         "misc/run-kwayland-check-wrapper.sh"
         "misc/run-kwayland-check.sh"
+        "misc/launch-dde-update"
         DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/dde-update/main.cpp
+++ b/src/dde-update/main.cpp
@@ -9,6 +9,7 @@
 #include "fullscreenbackground.h"
 #include "global_util/public_func.h"
 #include "updateworker.h"
+#include "securityloaderhelper.h"
 
 #include <DApplication>
 #include <DGuiApplicationHelper>
@@ -17,11 +18,117 @@
 
 #include <QCommandLineParser>
 #include <QCommandLineOption>
+#include <cstdlib>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <cerrno>
+#include <cstring>
 
 Q_LOGGING_CATEGORY(logUpdateModal, "dde.update.modalupdate")
 
 DCORE_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
+
+// Write all of `data` to `fd` opened O_NONBLOCK, using poll(2) for POLLOUT
+// on EAGAIN/EWOULDBLOCK instead of busy-looping. Returns true iff every byte
+// was written within `timeoutMs`. Handles EINTR for both write() and poll().
+static bool writeAllFifo(int fd, const QByteArray &data, int timeoutMs)
+{
+    ssize_t total = 0;
+    while (total < data.size()) {
+        ssize_t w = write(fd, data.constData() + total, data.size() - total);
+        if (w < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                struct pollfd pfd;
+                pfd.fd = fd;
+                pfd.events = POLLOUT;
+                int pr = -1;
+                do {
+                    pr = poll(&pfd, 1, timeoutMs);
+                } while (pr < 0 && errno == EINTR);
+                if (pr <= 0) {
+                    return false;
+                }
+                continue;
+            }
+            return false;
+        }
+        total += w;
+    }
+    return total == data.size();
+}
+
+// RAII notifier: writes to a FIFO on destruction so the launching script
+// can block until dde-update exits. Covers all return paths from main().
+class FifoNotifier
+{
+public:
+    explicit FifoNotifier(const QString &fifoPath)
+        : m_path(fifoPath)
+    {
+        reportPid();
+    }
+    ~FifoNotifier()
+    {
+        notify();
+    }
+    // Disable copy to avoid double-notify.
+    FifoNotifier(const FifoNotifier &) = delete;
+    FifoNotifier &operator=(const FifoNotifier &) = delete;
+
+private:
+    void reportPid()
+    {
+        if (m_path.isEmpty()) {
+            return;
+        }
+        // Write our PID so the wrapper can track this exact process via kill -0.
+        int fd = open(m_path.toUtf8().constData(), O_WRONLY | O_NONBLOCK);
+        if (fd < 0) {
+            qCWarning(logUpdateModal) << "FifoNotifier: cannot report PID, open failed:" << strerror(errno);
+            return;
+        }
+        QByteArray msg = "PID:" + QByteArray::number(getpid()) + "\n";
+        bool ok = writeAllFifo(fd, msg, 5000);
+        close(fd);
+        if (ok) {
+            qCInfo(logUpdateModal) << "FifoNotifier: reported PID" << getpid() << "to FIFO";
+        } else {
+            qCWarning(logUpdateModal) << "FifoNotifier: failed to report PID (write incomplete)";
+        }
+    }
+
+    void notify()
+    {
+        if (m_path.isEmpty()) {
+            return;
+        }
+        qCInfo(logUpdateModal) << "FifoNotifier: notifying FIFO" << m_path;
+        // O_NONBLOCK so we don't hang if the reader already closed;
+        // the script opens fd 3<> before launching us so a reader exists.
+        int fd = open(m_path.toUtf8().constData(), O_WRONLY | O_NONBLOCK);
+        if (fd < 0) {
+            qCWarning(logUpdateModal) << "FifoNotifier: cannot open" << m_path << ":" << strerror(errno);
+            return;
+        }
+        // Write "EXIT\n" to signal exit to the wrapper.
+        QByteArray msg("EXIT\n");
+        bool ok = writeAllFifo(fd, msg, 2000);
+        close(fd);
+        m_path.clear();
+        if (ok) {
+            qCInfo(logUpdateModal) << "FifoNotifier: exit notify sent (EXIT)";
+        } else {
+            qCWarning(logUpdateModal) << "FifoNotifier: failed to notify EXIT (write incomplete)";
+        }
+    }
+
+    QString m_path;
+};
 
 int main(int argc, char *argv[])
 {
@@ -59,6 +166,11 @@ int main(int argc, char *argv[])
     QCommandLineOption checkSystem(QStringList() << "c" << "check-upgrade", "Check if the update was successful.");
     QCommandLineOption checkSystemBeforeLogin(QStringList() << "b" << "before-login", "Check system before login.");
     QCommandLineOption checkSystemAfterLogin(QStringList() << "a" << "after-login", "Check system after login.");
+    QCommandLineOption notifyFifoOption(QStringList() << "notify-fifo", "FIFO path to notify on exit", "path");
+    // --fd1/--fd2 由 security-loader 注入, 注册给 parser 避免未知选项退出,
+    // 实际解析在 SecurityLoaderHelper::parseLoaderArgs 中完成
+    QCommandLineOption fd1Option(QStringList() << "fd1", "File descriptor for security loader communication", "fd");
+    QCommandLineOption fd2Option(QStringList() << "fd2", "File descriptor for security loader notification", "fd");
     QCommandLineParser parser;
     parser.setApplicationDescription("DDE UPGRADE");
     parser.addHelpOption();
@@ -67,7 +179,26 @@ int main(int argc, char *argv[])
     parser.addOption(checkSystem);
     parser.addOption(checkSystemBeforeLogin);
     parser.addOption(checkSystemAfterLogin);
+    parser.addOption(notifyFifoOption);
+    parser.addOption(fd1Option);
+    parser.addOption(fd2Option);
     parser.process(*app);
+
+    // Security loader handshake: parse --fd1/--fd2 injected by security-loader,
+    // perform D-Bus authorization handshake if loaded by loader. The handshake
+    // is best-effort: even if it fails we keep running, since the check is not
+    // strictly required for dde-update to function.
+    SecurityLoaderHelper securityLoader;
+    if (!securityLoader.doSecurityLoader(argc, argv)) {
+        qCWarning(logUpdateModal) << "Security loader handshake failed, continuing anyway";
+    }
+
+    // RAII: notifies the launching script via FIFO when main() returns (any exit path).
+    QString fifoPath = parser.value(notifyFifoOption);
+    if (!fifoPath.isEmpty()) {
+        qCInfo(logUpdateModal) << "FifoNotifier: enabled, FIFO path:" << fifoPath;
+    }
+    FifoNotifier fifoNotifier(fifoPath);
 
     DPalette pa = DGuiApplicationHelper::instance()->standardPalette(DGuiApplicationHelper::LightType);
     pa.setColor(QPalette::Normal, DPalette::WindowText, QColor("#FFFFFF"));
@@ -113,6 +244,7 @@ int main(int argc, char *argv[])
             qCWarning(logUpdateModal) << "Update options are invalid, check system stage:" << UpdateModel::instance()->checkSystemStage()
                 << ", check update mode:" << UpdateModel::instance()->updateMode();
 
+            qCInfo(logUpdateModal) << "Exiting: invalid update options (return 1)";
             return 1;
         }
     }
@@ -138,5 +270,7 @@ int main(int argc, char *argv[])
         UpdateWorker::instance()->checkSystem(UpdateModel::instance()->updateMode(), UpdateModel::instance()->checkSystemStage());
     }
 
-    return app->exec();
+    int ret = app->exec();
+    qCInfo(logUpdateModal) << "Exiting: app->exec() returned" << ret;
+    return ret;
 }

--- a/src/dde-update/misc/98deepin-upgrade-check
+++ b/src/dde-update/misc/98deepin-upgrade-check
@@ -18,7 +18,7 @@ if [ "$XDG_SESSION_TYPE" = "x11" ]; then
                     export $scale_env
                 fi
             fi
-            /usr/bin/dde-update
+            /usr/bin/dde-update --wait
         )
     fi
 elif [ "$XDG_SESSION_TYPE" = "wayland" ]; then

--- a/src/dde-update/misc/99_system_upgrade_conf.json
+++ b/src/dde-update/misc/99_system_upgrade_conf.json
@@ -1,4 +1,4 @@
 {
-    "ExecPath": "/usr/bin/dde-update",
+    "ExecPath": "/usr/libexec/deepin/dde-update",
     "NeedExecScript": "/usr/bin/system_upgrade_check.sh"
 }

--- a/src/dde-update/misc/dde-update
+++ b/src/dde-update/misc/dde-update
@@ -1,0 +1,157 @@
+#!/bin/bash
+#SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+#SPDX-License-Identifier: GPL-3.0-or-later
+
+TAG="dde-update"
+
+# 解析 --wait 参数: 启用时创建 FIFO 阻塞等待 dde-update 退出
+wait_mode=false
+pass_args=()
+for arg in "$@"; do
+    if [ "$arg" = "--wait" ]; then
+        wait_mode=true
+    else
+        pass_args+=("$arg")
+    fi
+done
+
+logger -t "$TAG" -p daemon.info "Starting dde-update via deepin-security-loader, args: ${pass_args[*]}, wait_mode: $wait_mode"
+
+if [ "$wait_mode" = "false" ]; then
+    # 非 wait 模式: 直接启动, 不阻塞
+    exec /usr/bin/deepin-security-loader --group deepin-daemon -- /usr/libexec/deepin/dde-update "${pass_args[@]}"
+fi
+
+# === wait 模式: FIFO + PID 跟踪 + 看门狗兜底 ===
+
+# 在私有临时目录中创建 FIFO, 避免 TOCTOU 竞态
+notify_dir=$(mktemp -d /tmp/dde-update-notify.XXXXXX) || {
+    logger -t "$TAG" -p daemon.err "Failed to create temp dir"
+    exit 1
+}
+chmod 700 "$notify_dir"
+notify_fifo="$notify_dir/notify.fifo"
+if ! mkfifo "$notify_fifo"; then
+    logger -t "$TAG" -p daemon.err "Failed to create FIFO: $notify_fifo"
+    rm -rf "$notify_dir"
+    exit 1
+fi
+logger -t "$TAG" -p daemon.info "Created notify FIFO: $notify_fifo"
+
+# 先打开双向 fd 持有读端, 防止 dde-update 竞态 open 失败
+exec 3<> "$notify_fifo" || {
+    logger -t "$TAG" -p daemon.err "Failed to open FIFO fd 3"
+    rm -rf "$notify_dir"
+    exit 1
+}
+logger -t "$TAG" -p daemon.info "FIFO fd 3 opened OK"
+
+# 看门狗 PID, 用于信号清理
+watchdog_pid=""
+
+# 清理函数: 关闭 fd、杀看门狗进程组、删临时目录。
+# 幂等, 可被 trap 和正常退出路径多次调用。
+cleanup() {
+    trap - INT TERM EXIT 2>/dev/null
+    if [ -n "$watchdog_pid" ]; then
+        kill -- -"$watchdog_pid" 2>/dev/null
+        wait "$watchdog_pid" 2>/dev/null
+        logger -t "$TAG" -p daemon.info "Watchdog (pgid=$watchdog_pid) cleaned up"
+    fi
+    exec 3>&- 2>/dev/null
+    rm -rf "$notify_dir" 2>/dev/null
+}
+trap cleanup INT TERM EXIT
+
+# security-loader 通过 setsid 将 dde-update 脱离当前会话启动, 无法阻塞等待;
+# --notify-fifo 透传给 dde-update, 启动时写 PID:xxx, 退出时写 EXIT。
+/usr/bin/deepin-security-loader --group deepin-daemon -- /usr/libexec/deepin/dde-update "${pass_args[@]}" --notify-fifo "$notify_fifo"
+rc=$?
+logger -t "$TAG" -p daemon.info "security-loader exited with code $rc"
+
+# 读取 dde-update 上报的 PID (30 秒超时, 处理启动前崩溃)
+if read -r -t 30 pid_line <&3; then
+    target_pid=$(echo "$pid_line" | sed -n 's/^PID:\([0-9]*\)$/\1/p')
+    if [ -z "$target_pid" ] || ! [ "$target_pid" -gt 0 ] 2>/dev/null; then
+        logger -t "$TAG" -p daemon.err "Unexpected or invalid FIFO data (not a PID): $pid_line, aborting"
+        exit 1
+    fi
+    logger -t "$TAG" -p daemon.info "Received PID from dde-update: $target_pid"
+else
+    # 无 PID 时不能继续阻塞: 3<> 持有写端, read 永远不会 EOF, 必须主动退出
+    logger -t "$TAG" -p daemon.err "Timeout waiting for PID from dde-update (30s), dde-update may have crashed before startup, aborting"
+    exit 1
+fi
+
+# 记录目标进程的启动时间, 防止 PID 复用导致误判
+target_starttime=$(awk '{n=split($0,a,") "); split(a[2],b," "); print b[20]}' /proc/$target_pid/stat 2>/dev/null)
+if [ -z "$target_starttime" ]; then
+    logger -t "$TAG" -p daemon.warning "Cannot read starttime for PID $target_pid, process may have already exited"
+fi
+logger -t "$TAG" -p daemon.info "Target PID: $target_pid, starttime: ${target_starttime:-unknown}"
+
+# 看门狗: dde-update 崩溃(SIGKILL/SEGV)时无法通知, 用 kill -0 + starttime 比较跟踪目标 PID。
+# 使用 setsid 放入独立进程组, 清理时杀整个进程组避免遗留孤儿 sleep。
+# 降级策略: starttime 为空时先 kill -0 判断进程是否仍存活,
+#   - 已消失: 直接发 EXIT 解除主循环阻塞 (PID 上报后立即崩溃的场景)
+#   - 仍存活但无法读 /proc: 启动仅基于 kill -0 的降级看门狗, 跳过 starttime 比较
+if [ -n "$target_starttime" ]; then
+    setsid bash -c '
+        sleep 2
+        while true; do
+            if ! kill -0 '"$target_pid"' 2>/dev/null; then
+                break
+            fi
+            current_starttime=$(awk "{n=split(\$0,a,\") \"); split(a[2],b,\" \"); print b[20]}" /proc/'"$target_pid"'/stat 2>/dev/null)
+            if [ "$current_starttime" != "'"$target_starttime"'" ]; then
+                logger -t "'"$TAG"'" "Watchdog: PID '"$target_pid"' reused (starttime changed: '"$target_starttime"' -> ${current_starttime:-N/A}), treating as exited"
+                break
+            fi
+            sleep 300
+        done
+        logger -t "'"$TAG"'" "Watchdog: dde-update (PID '"$target_pid"') no longer running, sending fallback notify"
+        echo "EXIT" > "'"$notify_fifo"'" 2>/dev/null
+    ' &
+    watchdog_pid=$!
+    logger -t "$TAG" -p daemon.info "Watchdog started (pgid=$watchdog_pid), tracking PID $target_pid (starttime=$target_starttime)"
+elif ! kill -0 "$target_pid" 2>/dev/null; then
+    # PID 已消失 (上报后立即崩溃): 直接发 EXIT, 无需看门狗
+    logger -t "$TAG" -p daemon.warning "PID $target_pid already gone (crashed after PID report), sending EXIT now"
+    echo "EXIT" > "$notify_fifo" 2>/dev/null
+else
+    # 进程仍存活但无法读 starttime: 降级看门狗, 仅用 kill -0, 不做 starttime 比较
+    logger -t "$TAG" -p daemon.warning "No starttime for PID $target_pid, starting degraded watchdog (kill -0 only)"
+    setsid bash -c '
+        sleep 2
+        while kill -0 '"$target_pid"' 2>/dev/null; do
+            sleep 300
+        done
+        logger -t "'"$TAG"'" "Watchdog(degraded): dde-update (PID '"$target_pid"') no longer running, sending fallback notify"
+        echo "EXIT" > "'"$notify_fifo"'" 2>/dev/null
+    ' &
+    watchdog_pid=$!
+    logger -t "$TAG" -p daemon.info "Degraded watchdog started (pgid=$watchdog_pid), tracking PID $target_pid"
+fi
+
+# 阻塞等待退出通知
+# FIFO 协议: PID:xxx = 进程上报, EXIT = 退出通知
+# 迟到的 PID 不能被误认为退出通知, 只接受 EXIT 行
+while read -r notify_line <&3; do
+    case "$notify_line" in
+        EXIT)
+            logger -t "$TAG" -p daemon.info "Received exit notify from FIFO"
+            break
+            ;;
+        PID:*)
+            logger -t "$TAG" -p daemon.warning "Received late PID message (ignored): $notify_line"
+            ;;
+        *)
+            logger -t "$TAG" -p daemon.warning "Unexpected FIFO data: $notify_line"
+            ;;
+    esac
+done
+
+logger -t "$TAG" -p daemon.info "dde-update finished, FIFO cleaning up"
+# cleanup 由 trap EXIT 触发, 负责关闭 fd3、杀看门狗、删临时目录 (rm -rf 幂等)
+exit 0

--- a/src/dde-update/misc/launch-dde-update
+++ b/src/dde-update/misc/launch-dde-update
@@ -1,0 +1,8 @@
+#!/bin/bash
+#SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+#SPDX-License-Identifier: GPL-3.0-or-later
+# launch-dde-update: 由 kwin --exit-with-session 调用, 作为中间层将 --wait 透传给 dde-update wrapper。
+# --exit-with-session 只接受路径不支持传参, 因此需要一个中间脚本。
+# 使用 exec 保持 PID 不变, 以便 kwin --exit-with-session 正确跟踪生命周期。
+exec /usr/bin/dde-update --wait

--- a/src/dde-update/misc/org.deepin.dde-update.json
+++ b/src/dde-update/misc/org.deepin.dde-update.json
@@ -1,0 +1,11 @@
+{
+    "version": "1.0",
+    "description": "dde-update 需要授权的 D-Bus 系统服务接口",
+    "DestList": [
+        {
+            "DbusName": "org.deepin.dde.Lastore1",
+            "DbusPath": "/org/deepin/dde/Lastore1",
+            "DbusInterface": "org.deepin.dde.Lastore1.Manager"
+        }
+    ]
+}

--- a/src/dde-update/misc/run-kwayland-check.sh
+++ b/src/dde-update/misc/run-kwayland-check.sh
@@ -42,4 +42,4 @@ fi
 
 #崩溃后重新登录会冲掉崩溃时候的kwin日志，此处加入一次拷贝，保证可以获取到kwin崩溃时候的那次日志
 mv $HOME/.kwin.log $HOME/.kwin-old.log
-/usr/bin/kwin_wayland  --exit-with-session=/usr/bin/dde-update -platform wayland-org.kde.kwin.qpa --xwayland --drm --no-lockscreen 1> $HOME/.kwin.log 2>&1
+/usr/bin/kwin_wayland  --exit-with-session=/usr/bin/launch-dde-update -platform wayland-org.kde.kwin.qpa --xwayland --drm --no-lockscreen 1> $HOME/.kwin.log 2>&1

--- a/src/dde-update/securityloaderhelper.cpp
+++ b/src/dde-update/securityloaderhelper.cpp
@@ -1,0 +1,286 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "securityloaderhelper.h"
+
+#include <QDebug>
+#include <QFile>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QDBusConnection>
+#include <unistd.h>
+#include <poll.h>
+#include <fcntl.h>
+#include <chrono>
+#include <cerrno>
+#include <cstring>
+#include <cstdlib>
+#include <climits>
+
+static const QString DEFAULT_AUTH_RESOURCE = ":/misc/org.deepin.dde-update.json";
+// Upper bound for the authorization response to guard against a misbehaving
+// loader that never closes its write end or streams excessive data.
+static constexpr int MAX_RESPONSE_BYTES = 1024 * 1024;  // 1 MiB
+// Loader-injected fds must not collide with the standard streams.
+static constexpr int MIN_VALID_FD = 3;
+
+bool SecurityLoaderHelper::doSecurityLoader(int argc, char *argv[])
+{
+    auto loaderInfo = parseLoaderArgs(argc, argv);
+    if (!loaderInfo.isLoadedByLoader) {
+        return true;
+    }
+
+    if (!loadDestList(DEFAULT_AUTH_RESOURCE)) {
+        qWarning() << "Failed to load DestList, cannot perform handshake";
+        if (loaderInfo.fd1 >= 0) close(loaderInfo.fd1);
+        if (loaderInfo.fd2 >= 0) close(loaderInfo.fd2);
+        return false;
+    }
+
+    if (!performHandshake(loaderInfo)) {
+        qWarning() << "Security loader handshake failed";
+        return false;
+    }
+    return true;
+}
+
+LoaderHandshakeInfo SecurityLoaderHelper::parseLoaderArgs(int argc, char *argv[])
+{
+    LoaderHandshakeInfo info;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--fd1") == 0 && i + 1 < argc) {
+            const char *val = argv[++i];
+            char *end = nullptr;
+            errno = 0;
+            long fd = strtol(val, &end, 10);
+            // Reject: no digits, trailing chars, range error, negative, or
+            // colliding with the standard streams.
+            if (end == val || *end != '\0' || errno == ERANGE
+                    || fd < 0 || fd > INT_MAX || fd < MIN_VALID_FD) {
+                qWarning() << "Invalid --fd1 value:" << val << ", ignoring";
+                continue;
+            }
+            info.fd1 = static_cast<int>(fd);
+            info.isLoadedByLoader = true;
+        } else if (strcmp(argv[i], "--fd2") == 0 && i + 1 < argc) {
+            const char *val = argv[++i];
+            char *end = nullptr;
+            errno = 0;
+            long fd = strtol(val, &end, 10);
+            if (end == val || *end != '\0' || errno == ERANGE
+                    || fd < 0 || fd > INT_MAX || fd < MIN_VALID_FD) {
+                qWarning() << "Invalid --fd2 value:" << val << ", ignoring";
+                continue;
+            }
+            info.fd2 = static_cast<int>(fd);
+        }
+    }
+
+    if (info.isLoadedByLoader) {
+        qInfo() << "Detected loader injection: fd1=" << info.fd1 << "fd2=" << info.fd2;
+    }
+
+    return info;
+}
+
+bool SecurityLoaderHelper::loadDestList(const QString &configPath)
+{
+    qInfo() << "Loading permission config from:" << configPath;
+
+    QFile file(configPath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning() << "Cannot open file:" << configPath;
+        return false;
+    }
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
+    file.close();
+
+    if (error.error != QJsonParseError::NoError) {
+        qWarning() << "JSON parse error in" << configPath << ":" << error.errorString();
+        return false;
+    }
+
+    QJsonObject root = doc.object();
+    if (!root.contains("DestList") || !root["DestList"].isArray()) {
+        qWarning() << "Invalid config format in" << configPath << ": missing DestList";
+        return false;
+    }
+
+    m_destList = root["DestList"].toArray();
+    qInfo() << "Loaded" << m_destList.size() << "D-Bus interfaces to authorize";
+    return !m_destList.isEmpty();
+}
+
+bool SecurityLoaderHelper::performHandshake(const LoaderHandshakeInfo &info)
+{
+    // Both fds must be valid to proceed; close whichever was injected.
+    if (!info.isLoadedByLoader || info.fd1 < 0 || info.fd2 < 0) {
+        qInfo() << "Not loaded by loader or fds incomplete, skipping handshake";
+        if (info.fd1 >= 0) close(info.fd1);
+        if (info.fd2 >= 0) close(info.fd2);
+        return true;
+    }
+
+    if (m_destList.isEmpty()) {
+        qWarning() << "No D-Bus interfaces loaded, skipping handshake";
+        close(info.fd1);
+        close(info.fd2);
+        return true;
+    }
+
+    qInfo() << "Performing loader handshake...";
+
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    if (!systemBus.isConnected()) {
+        qWarning() << "Cannot connect to system bus";
+        close(info.fd1);
+        close(info.fd2);
+        return false;
+    }
+
+    QString uniqueName = systemBus.baseService();
+    qInfo() << "System Bus UniqueName:" << uniqueName;
+
+    QJsonObject request;
+    request["UniqueName"] = uniqueName;
+    request["DestList"] = m_destList;
+
+    QByteArray jsonData = QJsonDocument(request).toJson(QJsonDocument::Compact);
+    qInfo() << "Sending request with" << m_destList.size() << "interfaces";
+
+    // Use POSIX write()/close() on the raw fd: QFile::open(fd, ...) defaults to
+    // DontCloseHandle so QFile::close() would not close the underlying fd,
+    // leaking it and blocking the loader on EOF.
+    {
+        const char *data = jsonData.constData();
+        ssize_t total = 0;
+        ssize_t remaining = jsonData.size();
+        while (remaining > 0) {
+            ssize_t w = write(info.fd1, data + total, remaining);
+            if (w < 0) {
+                if (errno == EINTR) {
+                    continue;
+                }
+                qWarning() << "write() to fd1 failed:" << strerror(errno);
+                close(info.fd1);
+                close(info.fd2);
+                return false;
+            }
+            total += w;
+            remaining -= w;
+        }
+        close(info.fd1);
+    }
+    qInfo() << "Sent authorization request to loader, bytes:" << jsonData.size();
+
+    // Set fd2 non-blocking so read() never hangs; poll() enforces a total
+    // deadline covering first-byte and all subsequent reads. If the loader
+    // writes a partial response and stalls, we still time out instead of
+    // blocking forever (which would orphan the GUI before FifoNotifier runs).
+    int fd2Flags = fcntl(info.fd2, F_GETFL);
+    if (fd2Flags < 0 || fcntl(info.fd2, F_SETFL, fd2Flags | O_NONBLOCK) < 0) {
+        qWarning() << "Cannot set fd2 non-blocking:" << strerror(errno);
+        close(info.fd2);
+        return false;
+    }
+
+    // Unified 5-second deadline for the entire response.
+    QByteArray response;
+    char buf[4096];
+    auto deadline = std::chrono::steady_clock::now()
+                  + std::chrono::milliseconds(5000);
+    while (true) {
+        int remainingMs = static_cast<int>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                deadline - std::chrono::steady_clock::now()).count());
+        if (remainingMs <= 0) {
+            qWarning() << "Timeout reading loader response (5000ms total)";
+            close(info.fd2);
+            return false;
+        }
+
+        struct pollfd pfd;
+        pfd.fd = info.fd2;
+        pfd.events = POLLIN;
+        int pret = -1;
+        do {
+            pret = poll(&pfd, 1, remainingMs);
+        } while (pret < 0 && errno == EINTR);
+        if (pret < 0) {
+            qWarning() << "poll() on fd2 failed:" << strerror(errno);
+            close(info.fd2);
+            return false;
+        }
+        if (pret == 0) {
+            qWarning() << "Timeout reading loader response (5000ms total)";
+            close(info.fd2);
+            return false;
+        }
+        if (pfd.revents & (POLLERR | POLLNVAL)) {
+            qWarning() << "poll() on fd2 returned error:" << pfd.revents;
+            close(info.fd2);
+            return false;
+        }
+        if (!(pfd.revents & (POLLIN | POLLHUP))) {
+            continue;
+        }
+
+        ssize_t n = read(info.fd2, buf, sizeof(buf));
+        if (n > 0) {
+            response.append(buf, n);
+            if (response.size() > MAX_RESPONSE_BYTES) {
+                qWarning() << "Authorization response exceeded" << MAX_RESPONSE_BYTES
+                           << "bytes, aborting";
+                close(info.fd2);
+                return false;
+            }
+            continue;
+        }
+        if (n == 0) {
+            // EOF: loader closed write end, message complete.
+            break;
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // Data not ready yet; loop back to poll with remaining deadline.
+            continue;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        qWarning() << "read() on fd2 failed:" << strerror(errno);
+        close(info.fd2);
+        return false;
+    }
+    close(info.fd2);
+
+    if (response.isEmpty()) {
+        qWarning() << "Empty response from loader";
+        return false;
+    }
+
+    QJsonParseError parseError;
+    QJsonDocument responseDoc = QJsonDocument::fromJson(response, &parseError);
+    if (parseError.error != QJsonParseError::NoError || !responseDoc.isObject()) {
+        qWarning() << "Invalid JSON response from loader:" << parseError.errorString();
+        return false;
+    }
+
+    QJsonObject result = responseDoc.object();
+    if (!result.contains("Result")) {
+        qWarning() << "Loader response missing 'Result' field";
+        return false;
+    }
+    if (result["Result"].toBool()) {
+        qInfo() << "Loader handshake completed successfully";
+        return true;
+    } else {
+        qWarning() << "Loader authorization denied:" << result["Message"].toString();
+        return false;
+    }
+}

--- a/src/dde-update/securityloaderhelper.h
+++ b/src/dde-update/securityloaderhelper.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SECURITYLOADERHELPER_H
+#define SECURITYLOADERHELPER_H
+
+#include <QString>
+#include <QJsonArray>
+
+struct LoaderHandshakeInfo {
+    int fd1 = -1;
+    int fd2 = -1;
+    bool isLoadedByLoader = false;
+};
+
+class SecurityLoaderHelper
+{
+public:
+    bool doSecurityLoader(int argc, char *argv[]);
+
+private:
+    LoaderHandshakeInfo parseLoaderArgs(int argc, char *argv[]);
+    bool loadDestList(const QString &configPath);
+    bool performHandshake(const LoaderHandshakeInfo &info);
+
+    QJsonArray m_destList;
+};
+
+#endif // SECURITYLOADERHELPER_H

--- a/src/dde-update/updateimages.qrc
+++ b/src/dde-update/updateimages.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
+        <file>misc/org.deepin.dde-update.json</file>
         <file>img/failed.svg</file>
         <file>img/success.svg</file>
         <file>img/uos_logo.svg</file>


### PR DESCRIPTION
feat: integrate security-loader and FIFO-based lifecycle management for dde-update

1. Add `securityloaderhelper` for D-Bus authorization handshake with deepin-security-loader when launched through the security framework
2. Introduce `FifoNotifier` RAII helper to notify the launching script when the process exits, covering all return paths from main()
3. Add wrapper script `/usr/bin/dde-update` for FIFO creation, PID tracking, watchdog fallback, and blocking exit notification via `--wait` mode
4. Add `launch-dde-update` intermediate script for kwin `--exit-with- session` compatibility, forwarding `--wait` to the wrapper
5. Move binary installation path from `/usr/bin` to `/usr/libexec/ deepin` for security-loader integration
6. Update ExecPath in `99_system_upgrade_conf.json` to reflect the new installation path
7. Update Wayland session script to use the new `launch-dde-update` wrapper
8. Add `org.deepin.dde-update.json` D-Bus permission configuration for Lastore interface access
9. Register `--fd1`/`--fd2` and `--notify-fifo` CLI options to support security-loader injection and exit notification

Log: Add security-loader support with FIFO-based process lifecycle management for dde-update

Influence:
1. Test dde-update launch without security-loader (normal startup path)
2. Test dde-update launch with security-loader (authorization handshake)
3. Verify FIFO exit notification works (covers all exit paths including crashes)
4. Test watchdog fallback when dde-update is killed without EXIT notification (SIGKILL/SEGV)
5. Verify wrapper cleanup (temp directory removal, fd closing, watchdog termination)
6. Test kwin --exit-with-session flow via launch-dde-update on Wayland
7. Verify configuration file changes do not break existing update functionality
8. Test upgrade check flow in both X11 and Wayland sessions

feat: 集成 security-loader 和基于 FIFO 的生命周期管理

1. 添加 `securityloaderhelper`，实现在通过安全框架启动时的 D-Bus 授权 握手
2. 引入 `FifoNotifier` RAII 辅助类，在进程退出时通知启动脚本，覆盖所有 main() 返回路径
3. 添加包装脚本 `/usr/bin/dde-update`，通过 `--wait` 模式实现 FIFO 创 建、PID 跟踪、看门狗兜底和阻塞退出通知
4. 添加 `launch-dde-update` 中间脚本，兼容 kwin `--exit-with-session` 调 用方式，透传 `--wait` 给包装脚本
5. 将二进制安装路径从 `/usr/bin` 改为 `/usr/libexec/deepin`，以便与 security-loader 集成
6. 更新 `99_system_upgrade_conf.json` 中的 ExecPath，使其指向新安装路径
7. 更新 Wayland 会话脚本，改用新的 `launch-dde-update` 包装脚本
8. 添加 `org.deepin.dde-update.json` D-Bus 权限配置文件，用于 Lastore 接 口访问
9. 注册 `--fd1`/`--fd2` 和 `--notify-fifo` 命令行选项，支持 security- loader 注入和退出通知

Log: 新增 security-loader 支持和基于 FIFO 的进程生命周期管理

Influence:
1. 测试不经过 security-loader 启动 dde-update（正常启动路径）
2. 测试经过 security-loader 启动 dde-update（授权握手流程）
3. 验证 FIFO 退出通知功能正常工作（覆盖所有退出路径，包括崩溃）
4. 测试 dde-update 被杀死时看门狗兜底机制（SIGKILL/SEGV 等无 EXIT 通知的 场景）
5. 验证包装脚本清理工作（临时目录删除、文件描述符关闭、看门狗终止）
6. 测试 Wayland 下通过 launch-dde-update 的 kwin --exit-with-session 流程
7. 验证配置文件变更不会破坏现有更新功能
8. 测试 X11 和 Wayland 会话下的升级检查流程

PMS: TASK-370161