### PR TITLE
feat(private-lastore-tray): stop animation when tray surface is hidden

### DIFF
--- a/src/private-lastore-tray/privatelastoreitem.cpp
+++ b/src/private-lastore-tray/privatelastoreitem.cpp
@@ -46,6 +46,15 @@ void PrivateLastoreItem::refreshTrayIcon()
     m_icon->setContentsMargins(0, 0, 0, 0);
 }
 
+void PrivateLastoreItem::setAnimationPaused(bool paused)
+{
+    if (paused) {
+        m_icon->stopAnimation();
+    } else {
+        onStartAnimation("");
+    }
+}
+
 void PrivateLastoreItem::onRefreshIcon(const QList<QDBusObjectPath> &jobs)
 {
     qInfo() << "Update job list changed";

--- a/src/private-lastore-tray/privatelastoreitem.h
+++ b/src/private-lastore-tray/privatelastoreitem.h
@@ -27,6 +27,7 @@ public:
 
     QWidget *tipsWidget();
     void refreshTrayIcon();
+    void setAnimationPaused(bool paused);
 
 protected:
     void resizeEvent(QResizeEvent *e);

--- a/src/private-lastore-tray/privatelastoreplugin.cpp
+++ b/src/private-lastore-tray/privatelastoreplugin.cpp
@@ -121,6 +121,7 @@ void PrivateLastorePlugin::updateDockHiddenSurfaceIds(bool shouldHide)
 {
     const QString surfaceId = "private-lastore::private-lastore";
     QStringList hiddenIds = m_dockTrayConfig->value("dockHiddenSurfaceIds").toStringList();
+    m_item->setAnimationPaused(shouldHide);
 
     if (shouldHide) {
         // 添加到隐藏列表


### PR DESCRIPTION
1. Stop the update animation when dock hides the tray surface (e.g., via hidden surface IDs)
2. Resume animation automatically when the surface is re-shown if update is still active
3. Avoid unnecessary CPU usage from animation timer while hidden

Log: Stop animation when dock hides the tray surface, resume on re-show
Influence: No animation when tray is hidden, auto-resume on re-show

feat(private-lastore-tray): 隐藏托盘时停止更新动画

1. 隐藏托盘 surface 时停止更新动画，避免不必要的 CPU 开销
2. 重新显示时自动根据当前更新状态决定是否恢复动画
3. 动画仅在托盘可见时运行

Log: 隐藏托盘时停止动画，重新显示时按需恢复
PMS: STORY-41025
Influence: 托盘隐藏时动画停止，重新显示时自动恢复

## Summary by Sourcery

Enhancements:
- Introduce a tray item API to pause or resume its animation and invoke it when the dock hides or shows the tray surface to avoid unnecessary animation while hidden.