### PR TITLE
fix: use branch ref instead of SHA for actions/checkout@v7

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -16,7 +16,7 @@ jobs:
       - run: export
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/heads/${{ github.head_ref }}
           persist-credentials: false
           allow-unsafe-pr-checkout: true
       - uses: linuxdeepin/action-cppcheck@main


### PR DESCRIPTION
## 问题

`actions/checkout@v7` 在使用 `ref: ${{ github.event.pull_request.head.sha }}` 时存在缺陷：

1. **`getRefSpec` 对 SHA 只 fetch 单个 commit**，不拉取完整分支历史
2. **`testRef` 对 SHA 永远返回 true**，不会触发第二次 targeted fetch
3. 当 PR 分支使用 `git commit --amend` 后，新的 commit SHA 不在本地 git 历史中，导致后续 `git diff base...head` 等命令失败

详情见 #318 的 CI 失败记录。

## 修复

将 `ref` 参数从裸 SHA 改为 `refs/heads/<branch>` 格式，使 `getRefSpecForAllHistory` 能正确处理分支 ref，`testRef` 也能在 force-push 后正确检测到 ref 变化并触发第二次 fetch。

## 变更文件

- `.github/workflows/cppcheck.yml`：`ref: ${{ github.event.pull_request.head.sha }}` → `ref: refs/heads/${{ github.head_ref }}`

## 其他受影响的工作流

`linuxdeepin/.github` 仓库中的多个 reusable workflow 也存在同样问题，需要单独修复：

- `.github/workflows/license-check.yml`（3 处）
- `.github/workflows/commitlint.yml`
- `.github/workflows/doc-check.yml`
- `.github/workflows/dtk-unittest.yml`
- `.github/workflows/build-distribution.yml`（4 处）
- `.github/workflows/auto-tag.yml`
- `workflow-templates/cppcheck.yml`

这些已准备好 patch，需要另提 PR 到 `linuxdeepin/.github` 仓库。

## Summary by Sourcery

Bug Fixes:
- Fix cppcheck workflow failures when pull request commits are amended or force-pushed by using the branch ref instead of the head SHA for actions/checkout.