### PR TITLE
fix: hand cursor on privacy policy link hover

### DIFF
--- a/src/dcc-update-plugin/qml/UpdateMain.qml
+++ b/src/dcc-update-plugin/qml/UpdateMain.qml
@@ -469,6 +469,11 @@ DccObject {
                     onLinkActivated: (link)=> {
                         dccData.work().openUrl(link)
                     }
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+                        acceptedButtons: Qt.NoButton
+                    }
                 }
             }
         }


### PR DESCRIPTION
关联 Multica issue: **DDE-54** — 【控制中心-系统更新】隐私政策超链接 hover 时光标未变为手指形状（需与 v20 一致）
PMS bug: https://pms.uniontech.com/bug-view-372287.html

## 问题

控制中心-系统更新页面检测到更新后，hover 到隐私政策超链接时光标未变为手指形状，与 v20 不一致。Qt Quick 的 `Text` 在富文本链接上 hover 时不会自动设置手型光标，需显式叠加 `MouseArea` 根据 `hoveredLink` 切换 `cursorShape`。

同插件 `dcc-update-plugin` 内其余 4 处富文本链接（`UpdateList.qml` ×2、`UpdateHistoryDialog.qml` ×2）均已做此处理，唯独 `UpdateMain.qml` 的 `privacyLabel` 遗漏。

## 改动

仅对 `src/dcc-update-plugin/qml/UpdateMain.qml` 的 `privacyLabel`（`D.Label`）新增 5 行 `MouseArea`，与同插件既有写法逐字节一致：

```qml
MouseArea {
    anchors.fill: parent
    cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
    acceptedButtons: Qt.NoButton
}
```

- hover 到《隐私政策》链接时光标切换为手型，与 v20 一致
- `acceptedButtons: Qt.NoButton` 不拦截按键事件，`onLinkActivated` 打开 URL 的既有点击路径完全不变
- 未改动任何已有属性/文本/逻辑；1 file changed, 5 insertions(+), 0 deletions

## 验证

- 代码审核：100 分，风险 Low，可直接合入
- 本地编译：pbuilder 全量构建通过（amd64），`qmlcachegen` 预编译 `UpdateMain.qml` 无语法错误，`.deb` 产物正常

## Summary by Sourcery

Bug Fixes:
- Fix missing hand cursor on hover for the privacy policy rich-text link in the system update view without altering click handling or other logic.