### PR TITLE
fix: bind fontManager to dialog labels/buttons for realtime font size update

### DIFF
--- a/src/dcc-update-plugin/qml/QuitTestingChannelDialog.qml
+++ b/src/dcc-update-plugin/qml/QuitTestingChannelDialog.qml
@@ -29,6 +29,7 @@ D.DialogWindow {
             text: qsTr("If you exit the beta program, you will no longer receive beta updates.")
             wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
+            font: D.DTK.fontManager.t8
         }
         RowLayout {
             Layout.topMargin: 10
@@ -37,6 +38,7 @@ D.DialogWindow {
             D.Button {
                 Layout.fillWidth: true
                 text: qsTr("Cancel")
+                font: D.DTK.fontManager.t6
                 onClicked: {
                     close()
                 }
@@ -44,6 +46,7 @@ D.DialogWindow {
             D.RecommandButton {
                 Layout.fillWidth: true
                 text: qsTr("Exit")
+                font: D.DTK.fontManager.t6
                 onClicked: {
                     bExit = true
                     close()

--- a/src/dcc-update-plugin/qml/QuitTestingChannelDialog.qml
+++ b/src/dcc-update-plugin/qml/QuitTestingChannelDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Layouts 1.15

--- a/src/dcc-update-plugin/qml/UpdateSelectDialog.qml
+++ b/src/dcc-update-plugin/qml/UpdateSelectDialog.qml
@@ -26,6 +26,7 @@ D.DialogWindow {
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             text: qsTr("The updates have been already downloaded. What do you want to do?")
+            font: D.DTK.fontManager.t8
         }
 
         Item {
@@ -70,6 +71,7 @@ D.DialogWindow {
 
             component ButtonWithToolTip: D.Button {
                 id: customButton
+                font: D.DTK.fontManager.t6
 
                 contentItem: Text {
                     id: buttonText


### PR DESCRIPTION
## Problem

更新方式选择弹窗（UpdateSelectDialog）和退出测试通道弹窗（QuitTestingChannelDialog）的字号不会跟随系统字号修改实时变更，需要重启控制中心才能生效。

根因：两个对话框都使用 `D.DialogWindow`（独立顶层窗口），其窗口字体在创建时确定，不会随系统字号变更自动更新。文件中的 `D.Label` / `Label` 和 `D.Button` / `D.RecommandButton` 均未绑定 `D.DTK.fontManager`，因此字号被冻结在创建时的状态。

## Changes

- `src/dcc-update-plugin/qml/UpdateSelectDialog.qml`
  - `D.Label` 添加 `font: D.DTK.fontManager.t8`
  - `ButtonWithToolTip` 内的 `D.Button` 添加 `font: D.DTK.fontManager.t6`
- `src/dcc-update-plugin/qml/QuitTestingChannelDialog.qml`（同类问题）
  - `Label` 添加 `font: D.DTK.fontManager.t8`
  - `D.Button` / `D.RecommandButton` 添加 `font: D.DTK.fontManager.t6`

字号选择（t8 用于内容文字、t6 用于按钮）与同模块 `UpdateControl.qml`、`UpdateHistoryDialog.qml` 中已有的约定一致。

## Testing

- 修改系统字号后，弹窗字体实时跟随变化（无需重启控制中心）
- 不同字号下弹窗布局正常、文字不截断
- 弹窗按钮文字大小与其他对话框一致

Ref: DDE-70

## Summary by Sourcery

Bind dialog labels and buttons in update-related QML dialogs to the global font manager so their font sizes update in real time with system font changes.

Bug Fixes:
- Ensure UpdateSelectDialog text and action buttons follow system font size changes without requiring a control center restart.
- Ensure QuitTestingChannelDialog text and action buttons follow system font size changes without requiring a control center restart.